### PR TITLE
CHANGE: reduce asteroid starting resources

### DIFF
--- a/runner/asteroids_redo.rb
+++ b/runner/asteroids_redo.rb
@@ -3,15 +3,15 @@ Location.where(location_type: 'asteroid_field').each do |loc|
   if loc.asteroids.count < 5
     if loc.system.low?
       rand(2..7).times do
-        Asteroid.create(location: loc, asteroid_type: rand(6), resources: 350000)
+        Asteroid.create(location: loc, asteroid_type: rand(6), resources: 125000)
       end
     elsif loc.system.wormhole?
       rand(1..3).times do
-        Asteroid.create(location: loc, asteroid_type: 6, resources: 350000)
+        Asteroid.create(location: loc, asteroid_type: 6, resources: 125000)
       end
     else
       rand(2..5).times do
-        Asteroid.create(location: loc, asteroid_type: rand(4), resources: 350000)
+        Asteroid.create(location: loc, asteroid_type: rand(4), resources: 125000)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Reduced the asteroid spawn resource values from 350k to 125k as it is currently impossible to flip an asteroid belt to allow other ore nodes to spawn

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
