### PR TITLE
Replace fragile nested hash lookups with centralized method access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ config/.DS_Store
 config/initializers/.DS_Store
 docker/.DS_Store
 public/.DS_Store
+
+spec/examples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem 'puma'
 # Docker
 gem 'tzinfo-data'
 
-# Misc
-gem 'awesome_print'
-
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
@@ -33,6 +30,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'simplecov'
   gem 'fuubar'
+  gem 'awesome_print'
 end
 
 group :production, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem 'puma'
 # Docker
 gem 'tzinfo-data'
 
+# Misc
+gem 'awesome_print'
+
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
@@ -29,6 +32,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'rails-controller-testing'
   gem 'simplecov'
+  gem 'fuubar'
 end
 
 group :production, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     acts_as_votable (0.12.0)
     arel (9.0.0)
     ast (2.4.0)
+    awesome_print (1.8.0)
     bcrypt (3.1.12)
     bootstrap4-kaminari-views (1.0.1)
       kaminari (>= 0.13)
@@ -99,6 +100,9 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
+    fuubar (2.3.2)
+      rspec-core (~> 3.0)
+      ruby-progressbar (~> 1.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (3.6.0)
@@ -324,6 +328,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   acts_as_votable
+  awesome_print
   bootstrap4-kaminari-views
   bugsnag
   bullet
@@ -334,6 +339,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  fuubar
   jquery-rails
   jquery-ui-rails
   kaminari

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,12 +26,12 @@ class ApplicationController < ActionController::Base
   end
 
   def call_police(player)
-    if !Npc.police.targeting_user(player).exists?
-      if player.system.high?
-        PoliceWorker.perform_async(player.id, 2)
-      elsif player.system.medium?
-        PoliceWorker.perform_async(player.id, 10)
-      end
+    return if Npc.police.targeting_user(player).exists?
+
+    if player.system.high?
+      PoliceWorker.perform_async(player.id, 2)
+    elsif player.system.medium?
+      PoliceWorker.perform_async(player.id, 10)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
   end
 
   def call_police(player)
-    if Npc.where(npc_type: 'police', target: player.id).empty?
+    if !Npc.police.targeting_user(player).exists?
       if player.system.high?
         PoliceWorker.perform_async(player.id, 2)
       elsif player.system.medium?

--- a/app/controllers/blueprints_controller.rb
+++ b/app/controllers/blueprints_controller.rb
@@ -8,7 +8,7 @@ class BlueprintsController < ApplicationController
       if params[:type] == 'item'
         price = Item.get_attribute(params[:loader], 'price') * 20 rescue nil
       else
-        price = Spaceship.ship_variables[params[:loader]]['price'] * 20 rescue nil
+        price = Spaceship.get_attribute(params[:loader], :price) * 20 rescue nil
       end
 
       if price && current_user.blueprints.where(loader: params[:loader]).empty?
@@ -32,7 +32,7 @@ class BlueprintsController < ApplicationController
       if params[:type] == 'item'
         render(partial: 'stations/blueprints/itemmodal', locals: { item: params[:loader] }) && (return)
       else
-        render(partial: 'stations/blueprints/shipmodal', locals: { key: params[:loader], value: Spaceship.ship_variables[params[:loader]] }) && (return)
+        render(partial: 'stations/blueprints/shipmodal', locals: { key: params[:loader], value: Spaceship.get_attribute(params[:loader]) }) && (return)
       end
     end
     render json: {}, status: 400

--- a/app/controllers/blueprints_controller.rb
+++ b/app/controllers/blueprints_controller.rb
@@ -6,7 +6,7 @@ class BlueprintsController < ApplicationController
   def buy
     if params[:loader] && params[:type] && current_user.location.research_station?
       if params[:type] == 'item'
-        price = get_item_attribute(params[:loader], 'price') * 20 rescue nil
+        price = Item.get_attribute(params[:loader], 'price') * 20 rescue nil
       else
         price = Spaceship.ship_variables[params[:loader]]['price'] * 20 rescue nil
       end

--- a/app/controllers/blueprints_controller.rb
+++ b/app/controllers/blueprints_controller.rb
@@ -6,7 +6,7 @@ class BlueprintsController < ApplicationController
   def buy
     if params[:loader] && params[:type] && current_user.location.research_station?
       if params[:type] == 'item'
-        price = Item.get_attribute(params[:loader], 'price') * 20 rescue nil
+        price = Item.get_attribute(params[:loader], :price) * 20 rescue nil
       else
         price = Spaceship.get_attribute(params[:loader], :price) * 20 rescue nil
       end

--- a/app/controllers/factories_controller.rb
+++ b/app/controllers/factories_controller.rb
@@ -20,7 +20,7 @@ class FactoriesController < ApplicationController
       if params[:type] == 'ship'
         ressources = Spaceship.get_attribute(params[:loader], :crafting) rescue nil
       elsif params[:loader].include?('equipment.')
-        ressources = Item.get_attribute(params[:loader], 'crafting')
+        ressources = Item.get_attribute(params[:loader], :crafting)
       else
         render(json: {}, status: 400) && (return)
       end
@@ -48,7 +48,7 @@ class FactoriesController < ApplicationController
           if params[:type] == 'ship'
             CraftJob.create(completion: DateTime.now + (Spaceship.get_attribute(params[:loader], :crafting_duration).to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
           else
-            CraftJob.create(completion: DateTime.now + (Item.get_attribute(params[:loader], 'crafting_duration').to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
+            CraftJob.create(completion: DateTime.now + (Item.get_attribute(params[:loader], :crafting_duration).to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
           end
         end
 

--- a/app/controllers/factories_controller.rb
+++ b/app/controllers/factories_controller.rb
@@ -8,7 +8,7 @@ class FactoriesController < ApplicationController
       if params[:type] == 'item'
         render(partial: 'stations/factory/itemmodal', locals: { item: params[:loader] }) && (return)
       else
-        render(partial: 'stations/factory/shipmodal', locals: { key: params[:loader], value: Spaceship.ship_variables[params[:loader]] }) && (return)
+        render(partial: 'stations/factory/shipmodal', locals: { key: params[:loader], value: Spaceship.get_attribute(params[:loader]) }) && (return)
       end
     end
     render json: {}, status: 400
@@ -18,7 +18,7 @@ class FactoriesController < ApplicationController
     if params[:loader] && params[:type] && params[:amount] && current_user.location.industrial_station?
 
       if params[:type] == 'ship'
-        ressources = Spaceship.ship_variables[params[:loader]]['crafting'] rescue nil
+        ressources = Spaceship.get_attribute(params[:loader], :crafting) rescue nil
       elsif params[:loader].include?('equipment.')
         ressources = Item.get_attribute(params[:loader], 'crafting')
       else
@@ -46,7 +46,7 @@ class FactoriesController < ApplicationController
 
           # Create CraftJob
           if params[:type] == 'ship'
-            CraftJob.create(completion: DateTime.now + (Spaceship.ship_variables[params[:loader]]['crafting_duration'].to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
+            CraftJob.create(completion: DateTime.now + (Spaceship.get_attribute(params[:loader], :crafting_duration).to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
           else
             CraftJob.create(completion: DateTime.now + (Item.get_attribute(params[:loader], 'crafting_duration').to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
           end

--- a/app/controllers/factories_controller.rb
+++ b/app/controllers/factories_controller.rb
@@ -20,7 +20,7 @@ class FactoriesController < ApplicationController
       if params[:type] == 'ship'
         ressources = Spaceship.ship_variables[params[:loader]]['crafting'] rescue nil
       elsif params[:loader].include?('equipment.')
-        ressources = get_item_attribute(params[:loader], 'crafting')
+        ressources = Item.get_attribute(params[:loader], 'crafting')
       else
         render(json: {}, status: 400) && (return)
       end
@@ -48,7 +48,7 @@ class FactoriesController < ApplicationController
           if params[:type] == 'ship'
             CraftJob.create(completion: DateTime.now + (Spaceship.ship_variables[params[:loader]]['crafting_duration'].to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
           else
-            CraftJob.create(completion: DateTime.now + (get_item_attribute(params[:loader], 'crafting_duration').to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
+            CraftJob.create(completion: DateTime.now + (Item.get_attribute(params[:loader], 'crafting_duration').to_f / 1440.0), loader: params[:loader], user: current_user, location: current_user.location)
           end
         end
 

--- a/app/controllers/market_controller.rb
+++ b/app/controllers/market_controller.rb
@@ -56,7 +56,7 @@ class MarketController < ApplicationController
         if listing.user
           listing.user.give_units(listing.price * amount * 0.95)
           if listing.item?
-            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_bought', amount: amount, name: get_item_attribute(listing.loader, "name")))
+            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_bought', amount: amount, name: Item.get_attribute(listing.loader, "name")))
           else
             ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_bought', amount: amount, name: listing.loader))
           end
@@ -138,7 +138,7 @@ class MarketController < ApplicationController
           if player_market
             MarketListing.create(loader: params[:loader], listing_type: 'item', location: current_user.location, price: price, amount: quantity, user: current_user)
           else
-            MarketListing.create(loader: params[:loader], listing_type: 'item', location: current_user.location, price: (get_item_attribute(params[:loader], 'price') * rabat).round, amount: quantity)
+            MarketListing.create(loader: params[:loader], listing_type: 'item', location: current_user.location, price: (Item.get_attribute(params[:loader], 'price') * rabat).round, amount: quantity)
           end
         elsif params[:type] == "ship"
           if player_market
@@ -167,7 +167,7 @@ class MarketController < ApplicationController
       # Find Loader
       if Spaceship.ship_variables.keys.include?(name)
         type = "ship"
-      elsif get_item_attribute(name[/\(.*?\)/].gsub("(", "").gsub(")", ""), "name")
+      elsif Item.get_attribute(name[/\(.*?\)/].gsub("(", "").gsub(")", ""), "name")
         type = "item"
         name = name[/\(.*?\)/].gsub("(", "").gsub(")", "")
       else
@@ -200,7 +200,7 @@ class MarketController < ApplicationController
         # If listing belonged to user -> notify
         if listing.user
           if listing.item?
-            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_sold', amount: amount, name: get_item_attribute(listing.loader, "name")))
+            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_sold', amount: amount, name: Item.get_attribute(listing.loader, "name")))
           else
             ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_sold', amount: amount, name: listing.loader))
           end
@@ -250,7 +250,7 @@ class MarketController < ApplicationController
       if quantity && (quantity.to_i > 0)
         if type == "item"
 
-          price = (get_item_attribute(loader, 'price') rescue 0) * 0.9
+          price = (Item.get_attribute(loader, 'price') rescue 0) * 0.9
 
           # Customization
           location = current_user.location

--- a/app/controllers/market_controller.rb
+++ b/app/controllers/market_controller.rb
@@ -138,7 +138,7 @@ class MarketController < ApplicationController
           if player_market
             MarketListing.create(loader: params[:loader], listing_type: 'item', location: current_user.location, price: price, amount: quantity, user: current_user)
           else
-            MarketListing.create(loader: params[:loader], listing_type: 'item', location: current_user.location, price: (Item.get_attribute(params[:loader], 'price') * rabat).round, amount: quantity)
+            MarketListing.create(loader: params[:loader], listing_type: 'item', location: current_user.location, price: (Item.get_attribute(params[:loader], :price) * rabat).round, amount: quantity)
           end
         elsif params[:type] == "ship"
           if player_market

--- a/app/controllers/market_controller.rb
+++ b/app/controllers/market_controller.rb
@@ -45,7 +45,7 @@ class MarketController < ApplicationController
           end
 
           amount.times do
-            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.get_attribute(listing.loader,:hp))
+            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.get_attribute(listing.loader, :hp))
           end
         end
 
@@ -230,7 +230,7 @@ class MarketController < ApplicationController
           Item.give_to_user(location: current_user.location, user: current_user, loader: listing.loader, amount: listing.amount)
         elsif listing.sell? && listing.ship?
           listing.amount.times do
-            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.get_attribute(listing.loader,:hp))
+            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.get_attribute(listing.loader, :hp))
           end
         end
 

--- a/app/controllers/market_controller.rb
+++ b/app/controllers/market_controller.rb
@@ -38,14 +38,14 @@ class MarketController < ApplicationController
         else
 
           # Check if met requirements
-          ship = Spaceship.ship_variables[listing.loader]
+          ship = Spaceship.get_attributes(listing.loader)
           if ship['faction'] && ship['reputation_requirement']
             rank = Faction.find(ship['faction']).get_rank(current_user)
             render(json: { 'error_message': I18n.t('errors.you_dont_have_the_required_reputation') }, status: 400) && (return) unless rank && (rank['type'] >= ship['reputation_requirement'])
           end
 
           amount.times do
-            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.ship_variables[listing.loader]['hp'])
+            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.get_attribute(listing.loader,:hp))
           end
         end
 
@@ -144,7 +144,7 @@ class MarketController < ApplicationController
           if player_market
             MarketListing.create(loader: params[:loader], listing_type: 'ship', location: current_user.location, price: price, amount: quantity, user: current_user)
           else
-            MarketListing.create(loader: params[:loader], listing_type: 'ship', location: current_user.location, price: (Spaceship.ship_variables[params[:loader]]['price'] * rabat).round, amount: quantity)
+            MarketListing.create(loader: params[:loader], listing_type: 'ship', location: current_user.location, price: (Spaceship.get_attribute(params[:loader], :price) * rabat).round, amount: quantity)
           end
         end
       end
@@ -230,7 +230,7 @@ class MarketController < ApplicationController
           Item.give_to_user(location: current_user.location, user: current_user, loader: listing.loader, amount: listing.amount)
         elsif listing.sell? && listing.ship?
           listing.amount.times do
-            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.ship_variables[listing.loader]['hp'])
+            Spaceship.create(location: current_user.location, user: current_user, name: listing.loader, hp: Spaceship.get_attribute(listing.loader,:hp))
           end
         end
 
@@ -250,7 +250,7 @@ class MarketController < ApplicationController
       if quantity && (quantity.to_i > 0)
         if type == "item"
 
-          price = (Item.get_attribute(loader, 'price') rescue 0) * 0.9
+          price = Item.get_attribute(loader, :price, default: 0) * 0.9
 
           # Customization
           location = current_user.location
@@ -263,7 +263,7 @@ class MarketController < ApplicationController
           end
 
         else
-          price = (Spaceship.ship_variables[loader]['price'] rescue 0) * 0.9
+          price = Spaceship.get_attribute(loader, :price, default: 0) * 0.9
         end
         listings = 1 if listings == 0
         price = price * quantity.to_i if price

--- a/app/controllers/market_controller.rb
+++ b/app/controllers/market_controller.rb
@@ -167,7 +167,7 @@ class MarketController < ApplicationController
       # Find Loader
       if Spaceship.ship_variables.keys.include?(name)
         type = "ship"
-      elsif Item.get_attribute(name[/\(.*?\)/].gsub("(", "").gsub(")", ""), "name")
+      elsif Item.get_attribute(name[/\(.*?\)/].gsub("(", "").gsub(")", ""), :name)
         type = "item"
         name = name[/\(.*?\)/].gsub("(", "").gsub(")", "")
       else

--- a/app/controllers/market_controller.rb
+++ b/app/controllers/market_controller.rb
@@ -56,7 +56,7 @@ class MarketController < ApplicationController
         if listing.user
           listing.user.give_units(listing.price * amount * 0.95)
           if listing.item?
-            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_bought', amount: amount, name: Item.get_attribute(listing.loader, "name")))
+            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_bought', amount: amount, name: Item.get_attribute(listing.loader, :name)))
           else
             ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_bought', amount: amount, name: listing.loader))
           end
@@ -200,7 +200,7 @@ class MarketController < ApplicationController
         # If listing belonged to user -> notify
         if listing.user
           if listing.item?
-            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_sold', amount: amount, name: Item.get_attribute(listing.loader, "name")))
+            ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_sold', amount: amount, name: Item.get_attribute(listing.loader, :name)))
           else
             ActionCable.server.broadcast("player_#{listing.user_id}", method: 'notify_info', text: I18n.t('notification.someone_sold', amount: amount, name: listing.loader))
           end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -174,8 +174,7 @@ class StationsController < ApplicationController
   private
 
   def check_police
-    police = Npc.where(target: current_user.id, npc_type: 'police') rescue nil
-    if police.count > 0
+    if Npc.police.targeting_user(current_user).exists?
       render(json: { 'error_message' => I18n.t('errors.police_inbound') }, status: 400) && (return)
     end
   end

--- a/app/controllers/structures_controller.rb
+++ b/app/controllers/structures_controller.rb
@@ -29,8 +29,12 @@ class StructuresController < ApplicationController
         end
         if items.present? && (structure.location == current_user.location)
           # Call police
-          call_police(current_user) if (structure.user != current_user) && (structure.structure_type != 'wreck') && !structure.user.in_same_fleet_as(current_user.id) && (structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime)
-
+          if (structure.user != current_user) &&
+             (structure.structure_type != 'wreck') &&
+             !structure.user.in_same_fleet_as(current_user) &&
+             (structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime)
+            call_police(current_user)
+          end
           # Check if player has enough space
           free_weight = current_user.active_spaceship.get_free_weight
           item_count = 0
@@ -75,7 +79,7 @@ class StructuresController < ApplicationController
       structure = Structure.find(params[:id]) rescue nil
       if structure && (structure.location == current_user.location)
         # Call police
-        call_police(current_user) if (structure.user != current_user) && (structure.structure_type != 'wreck') && !structure.user.in_same_fleet_as(current_user.id) && (structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime)
+        call_police(current_user) if (structure.user != current_user) && (structure.structure_type != 'wreck') && !structure.user.in_same_fleet_as(current_user) && (structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime)
         # Destroy Structure
         structure.destroy
         # Tell Players in location

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -78,7 +78,7 @@ class SystemsController < ApplicationController
       end
 
       # Check in combat
-      if User.where(target_id: current_user.id, is_attacking: true).count > 0 || Npc.targeting_user(current_user).exists?
+      if User.targeting_user(current_user).where(is_attacking: true).exists? || Npc.targeting_user(current_user).exists?
         render(json: { 'error_message' => I18n.t('errors.cant_do_that_whilst_in_combat') }, status: 400) && (return)
       end
 

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -78,7 +78,7 @@ class SystemsController < ApplicationController
       end
 
       # Check in combat
-      if User.where(target_id: current_user.id, is_attacking: true).count > 0 || Npc.where(target: current_user.id).count > 0
+      if User.where(target_id: current_user.id, is_attacking: true).count > 0 || Npc.targeting_user(current_user).exists?
         render(json: { 'error_message' => I18n.t('errors.cant_do_that_whilst_in_combat') }, status: 400) && (return)
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,25 +22,12 @@ module ApplicationHelper
     end
   end
 
-  def map_and_sort(users)
-    users = users.map { |u| { u.full_name => u.id } }.reduce(:merge)
-    if users
-      users.sort.to_h
-    else
-      {}
-    end
-  end
-
-  def get_item_attribute(loader, attribute)
-    begin
-      atty = loader.split(".")
-      out = Item.item_variables[atty[0]]
-      loader.count('.').times do |i|
-        out = out[atty[i + 1]]
-      end
-      out[attribute] rescue nil
-    rescue
-      ""
-    end
+  # return a sorted map of users
+  # { <user.full_name> => <user.id> }
+  def map_and_sort(user_query)
+    user_query.
+      select(:id, :full_name).
+      order(:family_name, :name).
+      pluck(:full_name, :id).to_h
   end
 end

--- a/app/lib/mission_generator.rb
+++ b/app/lib/mission_generator.rb
@@ -144,7 +144,7 @@ class MissionGenerator
       mission.mission_amount = ((difficulty + 1) * rand(5..10))
 
       # Set Reward
-      mission.reward = (Item.get_attribute(mission.mission_loader, 'price') * mission.mission_amount * rand(1.05..1.10)).round
+      mission.reward = (Item.get_attribute(mission.mission_loader, :price) * mission.mission_amount * rand(1.05..1.10)).round
     elsif mission.mission_type == 'vip'
       mission.enemy_amount = 3
       m_location = Location.where.not(faction_id: mission.faction_id).where("faction_id IS NOT NULL").order(Arel.sql("RANDOM()")).first

--- a/app/lib/mission_generator.rb
+++ b/app/lib/mission_generator.rb
@@ -144,7 +144,7 @@ class MissionGenerator
       mission.mission_amount = ((difficulty + 1) * rand(5..10))
 
       # Set Reward
-      mission.reward = (get_item_attribute(mission.mission_loader, 'price') * mission.mission_amount * rand(1.05..1.10)).round
+      mission.reward = (Item.get_attribute(mission.mission_loader, 'price') * mission.mission_amount * rand(1.05..1.10)).round
     elsif mission.mission_type == 'vip'
       mission.enemy_amount = 3
       m_location = Location.where.not(faction_id: mission.faction_id).where("faction_id IS NOT NULL").order(Arel.sql("RANDOM()")).first
@@ -172,15 +172,6 @@ class MissionGenerator
       Rails.logger.info mission.errors.full_messages
     end
 
-  end
-
-  def self.get_item_attribute(loader, attribute)
-    atty = loader.split(".")
-    out = Item.item_variables[atty[0]]
-    loader.count('.').times do |i|
-      out = out[atty[i + 1]]
-    end
-    out[attribute] rescue nil
   end
 
   # Abort Mission

--- a/app/models/concerns/has_lookup_attributes.rb
+++ b/app/models/concerns/has_lookup_attributes.rb
@@ -6,16 +6,28 @@ module HasLookupAttributes
   class_methods do
     attr_reader :default_base
 
-    def get_attribute(base, attribute, default: nil)
+    # Return a lookup attribute value using a combination of the `base` and `attribute`
+    # returns `default` if not found (which defaults to `nil`)
+    # e.g. `equipment.storage.small_black_hole.type`
+    def get_attribute(base, attribute = nil, default: nil)
       path = [base,attribute].compact.map(&:to_s).join('.')
-      # ap "get_attribute(#{path}, default: #{default ? default : 'nil'})"
+      # ap "#{self.name}.get_attribute(#{path}, default: #{default ? default : 'nil'})"
       parts = path.split('.')
       @lookup_data.dig(*parts) || default
+    end
+
+    # Return all the lookup attributes from a top-level key
+    def get_attributes(base)
+      self.get_attribute(base)
     end
   end
 
   def get_attribute(attribute = nil, default: nil)
     return nil if attribute.blank?
     self.class.get_attribute(self.send(self.class.default_base), attribute, default: default)
+  end
+
+  def get_attributes()
+    self.class.get_attribute(self.send(self.class.default_base))
   end
 end

--- a/app/models/concerns/has_lookup_attributes.rb
+++ b/app/models/concerns/has_lookup_attributes.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module HasLookupAttributes
+  extend ActiveSupport::Concern
+
+  class_methods do
+    attr_reader :default_base
+
+    def get_attribute(base, attribute, default: nil)
+      path = [base,attribute].compact.map(&:to_s).join('.')
+      # ap "get_attribute(#{path}, default: #{default ? default : 'nil'})"
+      parts = path.split('.')
+      @lookup_data.dig(*parts) || default
+    end
+  end
+
+  def get_attribute(attribute = nil, default: nil)
+    return nil if attribute.blank?
+    self.class.get_attribute(self.send(self.class.default_base), attribute, default: default)
+  end
+end

--- a/app/models/concerns/has_lookup_attributes.rb
+++ b/app/models/concerns/has_lookup_attributes.rb
@@ -10,7 +10,7 @@ module HasLookupAttributes
     # returns `default` if not found (which defaults to `nil`)
     # e.g. `equipment.storage.small_black_hole.type`
     def get_attribute(base, attribute = nil, default: nil)
-      path = [base,attribute].compact.map(&:to_s).join('.')
+      path = [base, attribute].compact.map(&:to_s).join('.')
       # ap "#{self.name}.get_attribute(#{path}, default: #{default ? default : 'nil'})"
       parts = path.split('.')
       @lookup_data.dig(*parts) || default

--- a/app/models/faction.rb
+++ b/app/models/faction.rb
@@ -1,18 +1,24 @@
 class Faction < ApplicationRecord
+  include HasLookupAttributes
+
   has_many :users
   has_many :missions, dependent: :destroy
   has_many :locations
 
-  @faction_variables = YAML.load_file("#{Rails.root.to_s}/config/variables/factions.yml")
+  @lookup_data = YAML.load_file("#{Rails.root.to_s}/config/variables/factions.yml")
+  @default_base = :id
 
-  # Get Attribute of faction
-  def get_attribute(attribute = nil)
-    Faction.faction_variables[self.id][attribute] rescue nil
+  ## — CLASS METHODS
+
+  def self.faction_variables
+    @lookup_data
   end
+
+  ## — INSTANCE METHODS
 
   # Get ticker of faction
   def get_ticker
-    "[#{Faction.faction_variables[self.id]['ticker']}]"
+    "[#{self.get_attribute(:ticker)}]"
   end
 
   # Get rank of user
@@ -29,8 +35,4 @@ class Faction < ApplicationRecord
     end
   end
 
-  # Factions
-  def self.faction_variables
-    @faction_variables
-  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,20 +1,16 @@
 class Item < ApplicationRecord
+  include HasLookupAttributes
+
+  ## -- RELATIONSHIPS
   belongs_to :user, optional: true
   belongs_to :location, optional: true
   belongs_to :spaceship, optional: true
   belongs_to :structure, optional: true
 
-  @item_variables = YAML.load_file("#{Rails.root.to_s}/config/variables/items.yml")
+  @lookup_data = YAML.load_file("#{Rails.root.to_s}/config/variables/items.yml")
+  @default_base = :loader
 
-  def self.get_attribute(loader, attribute, default: nil)
-    parts = "#{loader}.#{attribute}".split('.')
-    @item_variables.dig(*parts) || default
-  end
-
-  def get_attribute(attribute)
-    Item.get_attribute(self.loader, attribute)
-  end
-
+  ## — CLASS METHODS
   def self.remove_from_user(attr)
     user = attr[:user]
     if attr[:location]
@@ -155,5 +151,14 @@ class Item < ApplicationRecord
   # Delivery
   def self.delivery
     ["delivery.data", "delivery.intelligence"]
+  end
+
+  ## — INSTANCE METHODS
+  def total_price
+    self.get_attribute(:price, default: 0) * self.count
+  end
+
+  def total_weight
+    self.get_attribute(:weight, default: 0) * self.count
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,13 +6,13 @@ class Item < ApplicationRecord
 
   @item_variables = YAML.load_file("#{Rails.root.to_s}/config/variables/items.yml")
 
+  def self.get_attribute(loader, attribute, default: nil)
+    parts = "#{loader}.#{attribute}".split('.')
+    @item_variables.dig(*parts) || default
+  end
+
   def get_attribute(attribute)
-    atty = self.loader.split(".")
-    out = Item.item_variables[atty[0]]
-    self.loader.count('.').times do |i|
-      out = out[atty[i + 1]]
-    end
-    out[attribute]
+    Item.get_attribute(self.loader, attribute)
   end
 
   def self.remove_from_user(attr)

--- a/app/models/npc.rb
+++ b/app/models/npc.rb
@@ -1,13 +1,20 @@
 class Npc < ApplicationRecord
-  belongs_to :location, optional: true
+  include ApplicationHelper
 
+  ## -- RELATIONSHIPS
+  belongs_to :location, optional: true
+  belongs_to :target_user, class_name: User.name, foreign_key: :target, optional: true
+
+  ## -- ATTRIBUTES
   enum npc_type: [:enemy, :police, :politician, :bodyguard, :wanted_enemy]
   enum npc_state: [:created, :targeting, :attacking, :waiting]
 
   delegate :location_type, :enemy_amount, to: :location, prefix: true
 
-  include ApplicationHelper
+  ## -- SCOPES
+  scope :targeting_user, ->(user) { where(target: user.id) }
 
+  ## — INSTANCE METHODS
   # Lets the npc die
   def die
     NpcDiedWorker.perform_async(self.id)

--- a/app/models/npc.rb
+++ b/app/models/npc.rb
@@ -48,7 +48,7 @@ class Npc < ApplicationRecord
       @loader = Item.equipment.sample
       if Blueprint.where(loader: @loader, user: user).empty?
         Blueprint.create(user: user, loader: @loader, efficiency: 1)
-        ActionCable.server.broadcast("player_#{user.id}", method: 'notify_alert', text: I18n.t('notification.received_blueprint_destruction', name: get_item_attribute(@loader, 'name'), npc: self.name))
+        ActionCable.server.broadcast("player_#{user.id}", method: 'notify_alert', text: I18n.t('notification.received_blueprint_destruction', name: Item.get_attribute(@loader, 'name'), npc: self.name))
       end
     else
       @loader = Spaceship.ship_variables.keys.sample

--- a/app/models/npc.rb
+++ b/app/models/npc.rb
@@ -55,7 +55,7 @@ class Npc < ApplicationRecord
       @loader = Item.equipment.sample
       if Blueprint.where(loader: @loader, user: user).empty?
         Blueprint.create(user: user, loader: @loader, efficiency: 1)
-        ActionCable.server.broadcast("player_#{user.id}", method: 'notify_alert', text: I18n.t('notification.received_blueprint_destruction', name: Item.get_attribute(@loader, 'name'), npc: self.name))
+        ActionCable.server.broadcast("player_#{user.id}", method: 'notify_alert', text: I18n.t('notification.received_blueprint_destruction', name: Item.get_attribute(@loader, :name), npc: self.name))
       end
     else
       @loader = Spaceship.ship_variables.keys.sample

--- a/app/models/spaceship.rb
+++ b/app/models/spaceship.rb
@@ -305,7 +305,7 @@ class Spaceship < ApplicationRecord
 
   # Get HP Color Value
   def get_hp_color
-    percentage = self.hp / (Spaceship.ship_variables[name]['hp'] / 100.0)
+    percentage = self.hp / (get_attribute(:hp) / 100.0)
     case percentage
     when 0..29
       'color-red'

--- a/app/models/spaceship.rb
+++ b/app/models/spaceship.rb
@@ -1,17 +1,24 @@
 class Spaceship < ApplicationRecord
+  include HasLookupAttributes
+
+  ## -- RELATIONSHIPS
   belongs_to :user, optional: true
   belongs_to :location, optional: true
   has_many :items, dependent: :destroy
 
-  @ship_variables = YAML.load_file("#{Rails.root.to_s}/config/variables/spaceships.yml")
+  @lookup_data = YAML.load_file("#{Rails.root.to_s}/config/variables/spaceships.yml")
+  @default_base = :name
+
+  ## — CLASS METHODS
+  def self.ship_variables
+    @lookup_data
+  end
+
+  ## — INSTANCE METHODS
 
   # Get Weight of all Items in Ship
   def get_weight
-    weight = 0
-    Item.where(spaceship: self, equipped: false).each do |item|
-      weight = weight + item.get_attribute('weight') * item.count
-    end
-    weight
+    Item.where(spaceship: self, equipped: false).map(&:total_weight).sum
   end
 
   # Get free weight
@@ -19,84 +26,88 @@ class Spaceship < ApplicationRecord
     self.get_storage_capacity - self.get_weight
   end
 
-  # Get Attribute of ship
-  def get_attribute(attribute = nil)
-    Spaceship.ship_variables[self.name][attribute] rescue nil
-  end
-
   # Get Items in ship storage
   def get_items(equipped_switch = false)
-    equipped_switch ? Item.where(spaceship: self, equipped: false) : Item.where(spaceship: self)
+    query = self.items
+    query = query.where(equipped: false) if equipped_switch
+    query
   end
 
   # Get all Equipment in Ship
   def get_equipment
-    Item.where(spaceship: self).where("loader LIKE ?", "equipment%")
+    self.items.where("loader LIKE ?", "equipment%")
   end
 
   # Get all unequipped Equipment in Ship
   def get_unequipped_equipment
-    Item.where(spaceship: self, equipped: false).where("loader LIKE ?", "equipment%")
+    get_equipment.where(equipped: false)
   end
 
   # Get equipped Equipment in Ship
   def get_equipped_equipment
-    Item.where(spaceship: self, equipped: true).where("loader LIKE ?", "equipment%")
+    get_equipment.where(equipped: true)
+  end
+
+  def get_equipped_equipment_of_slot_type(type)
+    type = type.to_s
+    self.get_equipped_equipment.each_with_object([]) do |item, result|
+      result << item if item.get_attribute(:slot_type) == type
+    end
+  end
+
+  def get_equipped_equipment_of_type(type)
+    type = type.to_s
+    self.get_equipped_equipment.each_with_object([]) do |item, result|
+      result << item if item.get_attribute(:type) == type
+    end
   end
 
   # Get Main Equipment in Ship
   def get_main_equipment(active = false)
-    items = []
-    self.get_equipped_equipment.each do |item|
-      active ? (items << item if (item.get_attribute('slot_type') == "main") && item.active) : (items << item if item.get_attribute('slot_type') == "main")
-    end
+    items = get_equipped_equipment_of_slot_type(:main)
+    items = items.select(&:active) if active
     items
   end
 
   # Get Utility Equipment in Ship
   def get_utility_equipment
-    items = []
-    self.get_equipped_equipment.each do |item|
-      items << item if item.get_attribute('slot_type') == "utility"
-    end
-    items
+    get_equipped_equipment_of_slot_type(:utility)
   end
 
   # Deactivate Equipment
   def deactivate_equipment
     self.get_equipped_equipment.each do |item|
-      item.update_columns(active: false) if item.active
+      item.update(active: false)
     end
   end
 
   # Deactivate Weapons
   def deactivate_weapons
-    self.get_equipped_equipment.each do |item|
-      item.update_columns(active: false) if item.active && (item.get_attribute('type') == "Weapon")
+    self.get_equipped_equipment_of_type('Weapon').each do |item|
+      item.update(active: false)
     end
   end
 
   # Deactivate Selfrepair Equipment
   def deactivate_selfrepair_equipment
-    self.get_equipped_equipment.each do |item|
-      item.update_columns(active: false) if item.active && (item.get_attribute('type') == "Repair Bot")
+    self.get_equipped_equipment_of_type('Repair Bot').each do |item|
+      item.update_columns(active: false)
     end
   end
 
   # Deactivate Remoterepair Equipment
   def deactivate_remoterepair_equipment
-    self.get_equipped_equipment.each do |item|
-      item.update_columns(active: false) if item.active && (item.get_attribute('type') == "Repair Beam")
+    self.get_equipped_equipment_of_type('Repair Beam').each do |item|
+      item.update_columns(active: false)
     end
   end
 
   # Drop Loot
   def drop_loot
-    items = self.get_items
-    if items.present?
-      structure = Structure.create(location: self.user.location, structure_type: 'wreck')
+    if self.items.size.positive?
+      structure = Structure.create(location: self.user.location, structure_type: :wreck)
       hash = []
-      items.each do |item|
+      self.items.each do |item|
         if rand(0..1) == 1
           hash << { name: item.get_attribute('name'), dropped: true, amount: item.count, equipped: item.equipped }
           item.update_columns(structure_id: structure.id, spaceship_id: nil, equipped: false, count: item.count)
@@ -111,7 +122,7 @@ class Spaceship < ApplicationRecord
   # Get Storage Capacity of Ship
   def get_storage_capacity
     storage = self.get_attribute('storage')
-    storage = storage + (Spaceship.ship_variables[name]['upgrade']['storage_amplifier']**self.level).round if Spaceship.ship_variables[name]['upgrade']['storage_amplifier'] && (self.level > 0)
+    storage = storage + (self.get_attribute("upgrade.storage_amplifier", default: 1)**self.level).round if (self.level.positive?)
     stack = 0
     self.get_utility_equipment.each do |item|
       if (item.get_attribute('type') == "Storage") && item.equipped
@@ -119,11 +130,11 @@ class Spaceship < ApplicationRecord
         stack = stack + 1
       end
 
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['storage_amplifier'] if (Spaceship.ship_variables[name]['trait']['storage_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.storage_amplifier", default: 1) if item_attr
       item_attr = 0 unless item_attr
       storage = storage + storage * (item_attr / 100)
     end
-    storage = storage * self.user.faction.get_attribute('storage_amplifier')
+    storage = storage * self.user.faction.get_attribute('storage_amplifier', default: 1)
     storage.round
   end
 
@@ -132,7 +143,7 @@ class Spaceship < ApplicationRecord
     power = 0
     self.get_main_equipment.each do |item|
       item_attr = item.get_attribute('damage') if (item.get_attribute('type') == "Weapon") && item.equipped && item.active
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['damage_amplifier'] if (Spaceship.ship_variables[name]['trait']['damage_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.damage_amplifier", default: 1) if item_attr
       item_attr = 0 unless item_attr
       power = power + item_attr
     end
@@ -145,7 +156,7 @@ class Spaceship < ApplicationRecord
     repair = 0
     self.get_main_equipment.each do |item|
       item_attr = item.get_attribute('repair_amount') if (item.get_attribute('type') == "Repair Bot") && item.equipped && item.active
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['repair_amount_amplifier'] if (Spaceship.ship_variables[name]['trait']['repair_amount_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.repair_amount_amplifier", default: 1) if item_attr
       item_attr = 0 unless item_attr
       repair = repair + item_attr
     end
@@ -157,7 +168,7 @@ class Spaceship < ApplicationRecord
     repair = 0
     self.get_main_equipment.each do |item|
       item_attr = item.get_attribute('repair_amount') if (item.get_attribute('type') == "Repair Beam") && item.equipped && item.active
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['remote_repair_amplifier'] if (Spaceship.ship_variables[name]['trait']['remote_repair_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.remote_repair_amplifier", default: 1) if item_attr
       item_attr = 0 unless item_attr
       repair = repair + item_attr
     end
@@ -167,7 +178,7 @@ class Spaceship < ApplicationRecord
   # Get Defense of ship
   def get_defense
     defense = self.get_attribute('defense')
-    defense = defense + (Spaceship.ship_variables[name]['upgrade']['defense_amplifier']**self.level).round if Spaceship.ship_variables[name]['upgrade']['defense_amplifier'] && (self.level > 0)
+    defense = defense + (self.get_attribute("upgrade.defense_amplifier", default: 1)**self.level).round if self.level.positive?
     stack = 0
     self.get_utility_equipment.each do |item|
       if (item.get_attribute('type') == "Defense") && item.equipped
@@ -175,11 +186,11 @@ class Spaceship < ApplicationRecord
         stack = stack + 1
       end
 
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['defense_amplifier'] if (Spaceship.ship_variables[name]['trait']['defense_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.defense_amplifier", default: 1) if item_attr
       item_attr = 0 unless item_attr
       defense = defense + defense * (item_attr / 100)
     end
-    defense = defense * self.user.faction.get_attribute('defense_amplifier')
+    defense = defense * self.user.faction.get_attribute('defense_amplifier', default: 1)
     # cap to 70 max
     defense = 70 if defense > 70
     defense.round
@@ -190,7 +201,7 @@ class Spaceship < ApplicationRecord
     mining_amount = 0
     self.get_main_equipment.each do |item|
       item_attr = item.get_attribute('mining_amount') if (item.get_attribute('type') == "Mining Laser") && item.equipped
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['mining_amount_amplifier'] if (Spaceship.ship_variables[name]['trait']['mining_amount_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.mining_amount_amplifier", default: 1) if item_attr
       item_attr = 0 unless item_attr
       mining_amount = mining_amount + item_attr
     end
@@ -199,26 +210,18 @@ class Spaceship < ApplicationRecord
 
   # Get free main slots
   def get_free_main_slots
-    slots = self.get_attribute('main_equipment_slots')
-    self.get_equipment.each do |item|
-      slots = slots - 1 if (item.get_attribute('slot_type') == "main") && item.equipped
-    end
-    slots
+    self.get_attribute('main_equipment_slots') - get_main_equipment.select(&:equipped).size
   end
 
   # Get free utility slots
   def get_free_utility_slots
-    slots = self.get_attribute('utility_equipment_slots')
-    self.get_equipment.each do |item|
-      slots = slots - 1 if (item.get_attribute('slot_type') == "utility") && item.equipped
-    end
-    slots
+    self.get_attribute('utility_equipment_slots') - get_utility_equipment.select(&:equipped).size
   end
 
   # Get align time
   def get_align_time
     align_time = self.get_attribute('align_time')
-    align_time = align_time - (Spaceship.ship_variables[name]['upgrade']['align_amplifier']**self.level).round if Spaceship.ship_variables[name]['upgrade']['align_amplifier'] && (self.level > 0)
+    align_time = align_time - (self.get_attribute("upgrade.align_amplifier")**self.level).round if self.get_attribute("upgrade.align_amplifier") && (self.level > 0)
     stack = 0
     self.get_equipment.each do |item|
       if (item.get_attribute('type') == "Hull") && item.equipped
@@ -226,7 +229,7 @@ class Spaceship < ApplicationRecord
         stack = stack + 1
       end
 
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['align_amplifier'] if (Spaceship.ship_variables[name]['trait']['align_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.align_amplifier") if (self.get_attribute("trait.align_amplifier") rescue nil) && item_attr
       item_attr = 0 unless item_attr
       align_time = align_time - align_time * (item_attr / 100)
     end
@@ -236,7 +239,7 @@ class Spaceship < ApplicationRecord
   # Get target time
   def get_target_time
     target_time = self.get_attribute('target_time')
-    target_time = target_time - (Spaceship.ship_variables[name]['upgrade']['target_amplifier']**self.level).round if Spaceship.ship_variables[name]['upgrade']['target_amplifier'] && (self.level > 0)
+    target_time = target_time - (self.get_attribute("upgrade.target_amplifier")**self.level).round if self.get_attribute("upgrade.target_amplifier") && (self.level > 0)
     stack = 0
     self.get_equipment.each do |item|
       if (item.get_attribute('type') == "Sensor") && item.equipped
@@ -244,7 +247,7 @@ class Spaceship < ApplicationRecord
         stack = stack + 1
       end
 
-      item_attr = item_attr * Spaceship.ship_variables[name]['trait']['target_amplifier'] if (Spaceship.ship_variables[name]['trait']['target_amplifier'] rescue nil) && item_attr
+      item_attr = item_attr * self.get_attribute("trait.target_amplifier") if (self.get_attribute("trait.target_amplifier") rescue nil) && item_attr
       item_attr = 0 unless item_attr
       target_time = target_time - target_time * (item_attr / 100)
     end
@@ -258,7 +261,7 @@ class Spaceship < ApplicationRecord
       if user.active_spaceship.has_active_warp_disruptor
         user.active_spaceship.get_main_equipment(true).each do |item|
           item_attr = item.get_attribute('disrupt_strength') if (item.get_attribute('type') == "Warp Disruptor") && item.active && item.equipped
-          item_attr = item_attr * Spaceship.ship_variables[name]['trait']['warp_disrupt_amplifier'] if (Spaceship.ship_variables[name]['trait']['warp_disrupt_amplifier'] rescue nil) && item_attr
+          item_attr = item_attr * self.get_attribute("trait.warp_disrupt_amplifier") if (self.get_attribute("trait.warp_disrupt_amplifier") rescue nil) && item_attr
           item_attr = 0 unless item_attr
           weight = weight + (item_attr.round rescue 0)
         end
@@ -266,7 +269,7 @@ class Spaceship < ApplicationRecord
     end
     self.get_utility_equipment.each do |item|
       weight = weight - item.get_attribute('disrupt_immunity') if (item.get_attribute('type') == "Warp Core Stabilizer") && item.equipped
-      weight = weight - Spaceship.ship_variables[name]['trait']['disrupt_immunity'] if (Spaceship.ship_variables[name]['trait']['disrupt_immunity'] rescue nil)
+      weight = weight - self.get_attribute("trait.disrupt_immunity") if (self.get_attribute("trait.disrupt_immunity") rescue nil)
     end
     weight > 0 ? true : false
   end
@@ -281,15 +284,11 @@ class Spaceship < ApplicationRecord
 
   # Get value in credits of ship and its items
   def get_total_value
-    value = 0
-
     # Add ship
-    value = self.get_attribute('price')
+    value = self.get_attribute(:price, default: 0)
 
     # Add for items / equipment
-    self.get_items.each do |item|
-      value = value + item.get_attribute('price') * item.count
-    end
+    value += self.get_items.map(&:total_price).sum
 
     value
   end
@@ -300,7 +299,7 @@ class Spaceship < ApplicationRecord
     self.get_main_equipment.each do |item|
       attribute = attribute + item.get_attribute('scanner_range') if item.get_attribute('type') == "Scanner"
     end
-    attribute = attribute + Spaceship.ship_variables[name]['trait']['scanner_range'] if (Spaceship.ship_variables[name]['trait']['scanner_range'] rescue nil)
+    attribute = attribute + self.get_attribute("trait.scanner_range") if (self.get_attribute("trait.scanner_range") rescue nil)
     return attribute
   end
 
@@ -319,7 +318,7 @@ class Spaceship < ApplicationRecord
 
   # Check if has directional_scanner
   def get_directional_scanner
-    return true if (Spaceship.ship_variables[name]['trait']['directional_scanner'] rescue false)
+    return true if (self.get_attribute("trait.directional_scanner") rescue false)
     self.get_main_equipment().each do |item|
       return true if item.get_attribute('type') == 'Directional Scanner'
     end
@@ -328,24 +327,20 @@ class Spaceship < ApplicationRecord
 
   # Check if has jump drive
   def get_jump_drive
-    return true if (Spaceship.ship_variables[name]['trait']['jump_drive'] rescue false)
+    return true if (self.get_attribute("trait.jump_drive") rescue false)
     false
   end
 
   # Get max HP
   def get_max_hp
-    hp = Spaceship.ship_variables[name]['hp']
-    hp = hp + (Spaceship.ship_variables[name]['upgrade']['hp_amplifier']**self.level).round if Spaceship.ship_variables[name]['upgrade']['hp_amplifier'] && (self.level > 0)
+    hp = get_attribute(:hp)
+    hp += (self.get_attribute("upgrade.hp_amplifier", default: 0)**self.level).round if (self.level > 0)
     hp
   end
 
   # Repair
   def repair
-    self.update_columns(hp: self.get_max_hp)
+    self.update(hp: self.get_max_hp)
   end
 
-  # Ship Variables
-  def Spaceship.ship_variables
-    @ship_variables
-  end
 end

--- a/app/models/spaceship.rb
+++ b/app/models/spaceship.rb
@@ -104,7 +104,7 @@ class Spaceship < ApplicationRecord
 
   # Drop Loot
   def drop_loot
-    if self.items.size.positive?
+    if self.items.present?
       structure = Structure.create(location: self.user.location, structure_type: :wreck)
       hash = []
       self.items.each do |item|
@@ -122,7 +122,7 @@ class Spaceship < ApplicationRecord
   # Get Storage Capacity of Ship
   def get_storage_capacity
     storage = self.get_attribute('storage')
-    storage = storage + (self.get_attribute("upgrade.storage_amplifier", default: 1)**self.level).round if (self.level.positive?)
+    storage = storage + (self.get_attribute("upgrade.storage_amplifier", default: 1)**self.level).round if (self.level > 0)
     stack = 0
     self.get_utility_equipment.each do |item|
       if (item.get_attribute('type') == "Storage") && item.equipped
@@ -178,7 +178,7 @@ class Spaceship < ApplicationRecord
   # Get Defense of ship
   def get_defense
     defense = self.get_attribute('defense')
-    defense = defense + (self.get_attribute("upgrade.defense_amplifier", default: 1)**self.level).round if self.level.positive?
+    defense = defense + (self.get_attribute("upgrade.defense_amplifier", default: 1)**self.level).round if self.level > 0
     stack = 0
     self.get_utility_equipment.each do |item|
       if (item.get_attribute('type') == "Defense") && item.equipped

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,7 +121,7 @@ class User < ApplicationRecord
     # Destroy current spaceship of user and give him a nano if not insured
     old_ship = self.active_spaceship.destroy if self.active_spaceship
     if old_ship&.insured && !police
-      spaceship = Spaceship.create(user_id: self.id, name: old_ship.name, hp: Spaceship.get_attribute(old_ship.name,:hp))
+      spaceship = Spaceship.create(user_id: self.id, name: old_ship.name, hp: Spaceship.get_attribute(old_ship.name, :hp))
       self.update_columns(active_spaceship_id: spaceship.id)
     else
       self.give_nano

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,11 +2,17 @@ class User < ApplicationRecord
 
   acts_as_voter
 
+  ## -- RELATIONSHIPS
   belongs_to :faction, optional: true
   belongs_to :system, optional: true
   belongs_to :location, optional: true
   belongs_to :fleet, optional: true
   belongs_to :corporation, optional: true
+
+  belongs_to :target, class_name: User.name, foreign_key: :target_id, optional: true
+  belongs_to :active_spaceship, class_name: Spaceship.name, foreign_key: :active_spaceship_id, optional: true
+  belongs_to :mining_target, class_name: Asteroid.name, foreign_key: :mining_target_id, optional: true
+  belongs_to :npc_target, class_name: Npc.name, foreign_key: :npc_target_id, optional: true
 
   has_many :chat_messages, dependent: :destroy
   has_many :spaceships, dependent: :destroy
@@ -21,6 +27,7 @@ class User < ApplicationRecord
 
   has_and_belongs_to_many :chat_rooms
 
+  ## -- ATTRIBUTES
   enum corporation_role: [:recruit, :lieutenant, :commodore, :admiral, :founder]
 
   delegate :name, :security_status, to: :system, prefix: true
@@ -28,7 +35,7 @@ class User < ApplicationRecord
   delegate :name, to: :faction, prefix: true
   delegate :name, :ticker, to: :corporation, prefix: true
 
-  # Validations
+  ## -- VALIDATIONS
   validates :name, :family_name, :avatar, presence: true
   validates :name, uniqueness: { scope: :family_name }
   validates :email, uniqueness: true
@@ -42,9 +49,26 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook]
 
+  ## -- SCOPES
+  scope :targeting_user, ->(user) { where(target: user) }
+
+  ## -- CALLBACKS
   # Sets full name after create
-  after_create do
-    self.update_columns(full_name: "#{name} #{family_name}".downcase.titleize)
+  before_save do
+    self.full_name = "#{name} #{family_name}".downcase.titleize
+  end
+
+  before_destroy do
+    self.corporation.destroy if self.founder? && self.corporation # corporation
+    Friendship.where(friend_id: self.id).destroy_all # friendships
+    GameMail.where(sender_id: self.id).destroy_all # game mails
+  end
+
+  ## — CLASS METHODS
+  # Overridden from Devise to eager_load(:system, :active_spaceship)
+  def self.serialize_from_session(key, salt)
+    record = where(id: key).eager_load(:system, :active_spaceship).first
+    record if record && record.authenticatable_salt == salt
   end
 
   # Verify Avatar
@@ -53,12 +77,6 @@ class User < ApplicationRecord
               F_1 F_2 F_3 F_4 F_5 F_6 F_7 F_8 F_9 F_10 F_11 F_12 F_13 F_14 F_15).include?(self.avatar)
       errors.add(:avatar, "has not a correct value")
     end
-  end
-
-  before_destroy do
-    self.corporation.destroy if self.founder? && self.corporation # corporation
-    Friendship.where(friend_id: self.id).destroy_all # friendships
-    GameMail.where(sender_id: self.id).destroy_all # game mails
   end
 
   # Will be called when a user loggs in
@@ -71,29 +89,9 @@ class User < ApplicationRecord
     self.update_columns(target_id: nil) && DisappearWorker.perform_async(self.id)
   end
 
-  # Gets active spaceship of user
-  def active_spaceship
-    Spaceship.find(self.active_spaceship_id) rescue nil
-  end
-
   # Returns if player can be attacked
   def can_be_attacked
     !docked && !in_warp && (online > 0) && ((self.active_spaceship.hp rescue 0) > 0)
-  end
-
-  # Returns target of player
-  def target
-    User.find(target_id) rescue nil if target_id?
-  end
-
-  # Returns mining target of player
-  def mining_target
-    Asteroid.find(mining_target_id) rescue nil if mining_target_id?
-  end
-
-  # Returns npc target of player
-  def npc_target
-    Npc.find(npc_target_id) rescue nil if npc_target_id?
   end
 
   # Lets the player die
@@ -123,7 +121,7 @@ class User < ApplicationRecord
     # Destroy current spaceship of user and give him a nano if not insured
     old_ship = self.active_spaceship.destroy if self.active_spaceship
     if old_ship&.insured && !police
-      spaceship = Spaceship.create(user_id: self.id, name: old_ship.name, hp: Spaceship.ship_variables[old_ship.name]['hp'])
+      spaceship = Spaceship.create(user_id: self.id, name: old_ship.name, hp: Spaceship.get_attribute(old_ship.name,:hp))
       self.update_columns(active_spaceship_id: spaceship.id)
     else
       self.give_nano
@@ -143,23 +141,21 @@ class User < ApplicationRecord
   end
 
   # Returns if user is in same fleet with given id
-  def in_same_fleet_as(id)
-    f_id = self.fleet_id
-    (f_id != nil) && (f_id == User.find(id).fleet_id)
+  def in_same_fleet_as(other_user)
+    self.fleet_id && self.fleet_id == other_user.fleet_id
   end
 
   # Returns if user is in same fleet with given id
-  def in_same_corporation_as(id)
-    f_id = self.corporation_id
-    (f_id != nil) && (f_id == User.find(id).corporation_id)
+  def in_same_corporation_as(other_user)
+    self.corporation_id && self.corporation_id == other_user.corporation_id
   end
 
   # Gets the user remove being a target of other players
   def remove_being_targeted
-    Npc.where(target: self.id).update_all(target: nil)
-    User.where(target_id: self.id).each do |user|
+    Npc.targeting_user(self).update_all(target: nil)
+    User.targeting_user(self).each do |user|
       user.update_columns(target_id: nil)
-      user.active_spaceship.deactivate_equipment if user.is_attacking
+      user.active_spaceship.deactivate_equipment if user.is_attacking?
       ActionCable.server.broadcast("player_#{user.id}", method: 'remove_target')
     end
   end
@@ -181,7 +177,7 @@ class User < ApplicationRecord
 
   # Returns if player can buy a ship
   def can_buy_ship(name)
-    ship_vars = Spaceship.ship_variables[name]
+    ship_vars = Spaceship.get_attribute(name)
     ship_vars && (self.units >= ship_vars['price']) && self.location.get_ships_for_sale.has_key?(name)
   end
 

--- a/app/views/equipment/_info.html.erb
+++ b/app/views/equipment/_info.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= Item.get_attribute(item, 'name') %></h5>
+        <h5 class="modal-title"><%= Item.get_attribute(item, :name) %></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/app/views/equipment/_info.html.erb
+++ b/app/views/equipment/_info.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= get_item_attribute(item, 'name') %></h5>
+        <h5 class="modal-title"><%= Item.get_attribute(item, 'name') %></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/app/views/factions/index.html.erb
+++ b/app/views/factions/index.html.erb
@@ -24,18 +24,18 @@
       <% @factions.each_with_index do |faction, index| %>
         <div class="col-md-4 mb-3" style="position:relative">
           <div class="display mb-3 text-center">
-            <%= image_tag("ships/#{Faction.faction_variables[faction.id]['placeholder']}") %>
+            <%= image_tag("ships/#{faction.get_attribute(:placeholder)}") %>
           </div>
-          
+
           <h5><%= faction.name %></h5>
-          
+
           <p><%= faction.description %></p>
-          
+
           <div class="<%= 'grounded' if index > 0 %>">
             <h5><%= I18n.t('factions.bonus') %></h5>
-          
+
             <p class="color-green"><%= I18n.t("factions.#{faction.id}_bonus") %></p>
-            
+
             <%= button_to choose_faction_path(id: faction.id), class: 'btn btn-primary btn-load', method: :post do %>
               <span><%= I18n.t('factions.choose') %></span>
               &nbsp;<i class="fas fa-arrow-right"></i>
@@ -59,7 +59,7 @@
       </div>
       <div class="modal-body">
         <p><%= I18n.t('tutorial.before_you_continue_text') %></p>
-        
+
         <div class="row">
           <div class="col-6">
             <a href="https://forums.stellar-invictus.com/t/piloting-101-a-guide-for-new-players" target="_blank" class="btn btn-outline-primary w-100"><%= I18n.t('tutorial.quickstart_guide') %></a>

--- a/app/views/game/_locations_table.html.erb
+++ b/app/views/game/_locations_table.html.erb
@@ -11,7 +11,7 @@
     <% locations.each do |location| %>
       <% next if location == @current_user.location || (location.wormhole? and current_user.active_spaceship.get_scanner_range < 10) %>
       <% if location.mission.present? %>
-        <% next unless (location.mission.active? and location.mission.user == current_user) || (location.mission.user and location.mission.user.in_same_fleet_as(current_user.id)) %>
+        <% next unless (location.mission.active? and location.mission.user == current_user) || (location.mission.user and location.mission.user.in_same_fleet_as(current_user)) %>
       <% end %>
       <%= render partial: 'game/location', locals: {location: location} %>
     <% end %>

--- a/app/views/game/_players.html.erb
+++ b/app/views/game/_players.html.erb
@@ -17,7 +17,7 @@
         <%= render 'game/structure_info' %>
         <% local_users.each do |user| %>
           <% next if user.id == @current_user.id %>
-          <tr class="<%= 'target-flash' if user.target == current_user and !user.is_attacking %> <%= 'table-fleet' if user.in_same_fleet_as(current_user.id) %> <%= 'table-corporation' if user.in_same_corporation_as(current_user.id) %>">
+          <tr class="<%= 'target-flash' if user.target == current_user and !user.is_attacking %> <%= 'table-fleet' if user.in_same_fleet_as(current_user) %> <%= 'table-corporation' if user.in_same_corporation_as(current_user) %>">
             <td><%= image_tag('icons/helmet.png') %></td>
             <td class="players-card-name-td"><%= user.full_name %></td>
             <td><%= user.active_spaceship.name rescue "" %></td>

--- a/app/views/game/targets/_player.html.erb
+++ b/app/views/game/targets/_player.html.erb
@@ -1,4 +1,4 @@
-<% enemy_vars = Spaceship.ship_variables[current_user.target.active_spaceship.name] %>
+<% enemy_vars = current_user.target.active_spaceship.get_attributes %>
 <div class="col-6 enemy-space-ship" data-ship-image="<%= image_path("ships/#{enemy_vars['thruster-image']}") %>" style="<%= 'border: 1px solid red' if current_user.is_attacking %>">
 </div>
 <div class="col-6 text-left enemy-space-ship-infos">

--- a/app/views/items/_vars.html.erb
+++ b/app/views/items/_vars.html.erb
@@ -1,65 +1,65 @@
-<p><%= I18n.t("equipment.#{Item.get_attribute(item, 'type').downcase.gsub(' ', '_')}_text") %></p>
+<p><%= I18n.t("equipment.#{Item.get_attribute(item, :type).downcase.gsub(' ', '_')}_text") %></p>
 
 <p><strong><%= I18n.t('equipment.statistics') %></strong></p>
 <table class="table table-bordered table-sm table-striped">
   <tr>
     <th><%= I18n.t('equipment.weight') %></th>
-    <td><%= Item.get_attribute(item, 'weight') %></td>
+    <td><%= Item.get_attribute(item, :weight) %></td>
   </tr>
   <tr>
     <th><%= I18n.t('equipment.slot_type') %></th>
-    <td><%= Item.get_attribute(item, 'slot_type').capitalize %></td>
+    <td><%= Item.get_attribute(item, :slot_type).capitalize %></td>
   </tr>
-  <% case Item.get_attribute(item, 'type') %>
+  <% case Item.get_attribute(item, :type) %>
   <% when "Weapon" %>
     <tr>
       <th><%= I18n.t('equipment.damage') %></th>
-      <td><%= Item.get_attribute(item, 'damage') %></td>
+      <td><%= Item.get_attribute(item, :damage) %></td>
     </tr>
   <% when "Defense" %>
     <tr>
       <th><%= I18n.t('equipment.defense_amplifier') %></th>
-      <td><%= Item.get_attribute(item, 'defense_amplifier') %></td>
+      <td><%= Item.get_attribute(item, :defense_amplifier) %></td>
     </tr>
   <% when "Storage" %>
     <tr>
       <th><%= I18n.t('equipment.storage_amplifier') %></th>
-      <td><%= Item.get_attribute(item, 'storage_amplifier') %></td>
+      <td><%= Item.get_attribute(item, :storage_amplifier) %></td>
     </tr>
   <% when "Mining Laser" %>
     <tr>
       <th><%= I18n.t('equipment.mining_amount') %></th>
-      <td><%= Item.get_attribute(item, 'mining_amount') %></td>
+      <td><%= Item.get_attribute(item, :mining_amount) %></td>
     </tr>
   <% when "Hull" %>
     <tr>
       <th><%= I18n.t('equipment.align_amplifier') %></th>
-      <td><%= Item.get_attribute(item, 'align_amplifier') %></td>
+      <td><%= Item.get_attribute(item, :align_amplifier) %></td>
     </tr>
   <% when "Sensor" %>
     <tr>
       <th><%= I18n.t('equipment.target_amplifier') %></th>
-      <td><%= Item.get_attribute(item, 'target_amplifier') %></td>
+      <td><%= Item.get_attribute(item, :target_amplifier) %></td>
     </tr>
   <% when "Scanner" %>
     <tr>
       <th><%= I18n.t('equipment.scanner_range') %></th>
-      <td><%= Item.get_attribute(item, 'scanner_range') %></td>
+      <td><%= Item.get_attribute(item, :scanner_range) %></td>
     </tr>
   <% when "Repair Bot", "Repair Beam" %>
     <tr>
       <th><%= I18n.t('equipment.repair_amount') %></th>
-      <td><%= Item.get_attribute(item, 'repair_amount') %></td>
+      <td><%= Item.get_attribute(item, :repair_amount) %></td>
     </tr>
   <% when "Warp Disruptor" %>
     <tr>
       <th><%= I18n.t('equipment.disrupt_strength') %></th>
-      <td><%= Item.get_attribute(item, 'disrupt_strength') %></td>
+      <td><%= Item.get_attribute(item, :disrupt_strength) %></td>
     </tr>
   <% when "Warp Core Stabilizer" %>
     <tr>
       <th><%= I18n.t('equipment.disrupt_immunity') %></th>
-      <td><%= Item.get_attribute(item, 'disrupt_immunity') %></td>
+      <td><%= Item.get_attribute(item, :disrupt_immunity) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/items/_vars.html.erb
+++ b/app/views/items/_vars.html.erb
@@ -1,65 +1,65 @@
-<p><%= I18n.t("equipment.#{get_item_attribute(item, 'type').downcase.gsub(' ', '_')}_text") %></p>
+<p><%= I18n.t("equipment.#{Item.get_attribute(item, 'type').downcase.gsub(' ', '_')}_text") %></p>
 
 <p><strong><%= I18n.t('equipment.statistics') %></strong></p>
 <table class="table table-bordered table-sm table-striped">
   <tr>
     <th><%= I18n.t('equipment.weight') %></th>
-    <td><%= get_item_attribute(item, 'weight') %></td>
+    <td><%= Item.get_attribute(item, 'weight') %></td>
   </tr>
   <tr>
     <th><%= I18n.t('equipment.slot_type') %></th>
-    <td><%= get_item_attribute(item, 'slot_type').capitalize %></td>
+    <td><%= Item.get_attribute(item, 'slot_type').capitalize %></td>
   </tr>
-  <% case get_item_attribute(item, 'type') %>
+  <% case Item.get_attribute(item, 'type') %>
   <% when "Weapon" %>
     <tr>
       <th><%= I18n.t('equipment.damage') %></th>
-      <td><%= get_item_attribute(item, 'damage') %></td>
+      <td><%= Item.get_attribute(item, 'damage') %></td>
     </tr>
   <% when "Defense" %>
     <tr>
       <th><%= I18n.t('equipment.defense_amplifier') %></th>
-      <td><%= get_item_attribute(item, 'defense_amplifier') %></td>
+      <td><%= Item.get_attribute(item, 'defense_amplifier') %></td>
     </tr>
   <% when "Storage" %>
     <tr>
       <th><%= I18n.t('equipment.storage_amplifier') %></th>
-      <td><%= get_item_attribute(item, 'storage_amplifier') %></td>
+      <td><%= Item.get_attribute(item, 'storage_amplifier') %></td>
     </tr>
   <% when "Mining Laser" %>
     <tr>
       <th><%= I18n.t('equipment.mining_amount') %></th>
-      <td><%= get_item_attribute(item, 'mining_amount') %></td>
+      <td><%= Item.get_attribute(item, 'mining_amount') %></td>
     </tr>
   <% when "Hull" %>
     <tr>
       <th><%= I18n.t('equipment.align_amplifier') %></th>
-      <td><%= get_item_attribute(item, 'align_amplifier') %></td>
+      <td><%= Item.get_attribute(item, 'align_amplifier') %></td>
     </tr>
   <% when "Sensor" %>
     <tr>
       <th><%= I18n.t('equipment.target_amplifier') %></th>
-      <td><%= get_item_attribute(item, 'target_amplifier') %></td>
+      <td><%= Item.get_attribute(item, 'target_amplifier') %></td>
     </tr>
   <% when "Scanner" %>
     <tr>
       <th><%= I18n.t('equipment.scanner_range') %></th>
-      <td><%= get_item_attribute(item, 'scanner_range') %></td>
+      <td><%= Item.get_attribute(item, 'scanner_range') %></td>
     </tr>
   <% when "Repair Bot", "Repair Beam" %>
     <tr>
       <th><%= I18n.t('equipment.repair_amount') %></th>
-      <td><%= get_item_attribute(item, 'repair_amount') %></td>
+      <td><%= Item.get_attribute(item, 'repair_amount') %></td>
     </tr>
   <% when "Warp Disruptor" %>
     <tr>
       <th><%= I18n.t('equipment.disrupt_strength') %></th>
-      <td><%= get_item_attribute(item, 'disrupt_strength') %></td>
+      <td><%= Item.get_attribute(item, 'disrupt_strength') %></td>
     </tr>
   <% when "Warp Core Stabilizer" %>
     <tr>
       <th><%= I18n.t('equipment.disrupt_immunity') %></th>
-      <td><%= get_item_attribute(item, 'disrupt_immunity') %></td>
+      <td><%= Item.get_attribute(item, 'disrupt_immunity') %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/ships/_upgrade_modal.html.erb
+++ b/app/views/ships/_upgrade_modal.html.erb
@@ -16,7 +16,7 @@
           <table class="table table-bordered table-striped table-sm mb-3">
             <% Spaceship.ship_variables[ship.name]['upgrade']['ressources'].each do |k, v| %>
               <tr>
-                <th><%= get_item_attribute(k, 'name') %></th>
+                <th><%= Item.get_attribute(k, 'name') %></th>
                 <th><%= Item.find_by(user: current_user, location: current_user.location, loader: k).count rescue 0 %> /  <%= v %>&times;</th>
               </tr>
             <% end %>

--- a/app/views/ships/_upgrade_modal.html.erb
+++ b/app/views/ships/_upgrade_modal.html.erb
@@ -1,3 +1,4 @@
+<%- upgrade_attrs = ship.get_attribute(:upgrade) %>
 <div class="modal fade" tabindex="-1" role="dialog" id="ship-upgrade-modal">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -8,13 +9,13 @@
         </button>
       </div>
       <div class="modal-body text-white">
-        <% if Spaceship.ship_variables[ship.name]['upgrade'] and ship.level < 5 %>
-          <p><%= I18n.t("ships.upgrade_current_bonus_#{Spaceship.ship_variables[ship.name]['upgrade'].keys.first}") %>: <span class="color-highgreen"><%= ship.level == 0 ? 0.0 : (Spaceship.ship_variables[ship.name]['upgrade'][Spaceship.ship_variables[ship.name]['upgrade'].keys.first] ** ship.level).round.to_f %></span></p>
-          <p><%= I18n.t('ships.upgrade_value_after') %>: <span class="color-highgreen"><%= (Spaceship.ship_variables[ship.name]['upgrade'][Spaceship.ship_variables[ship.name]['upgrade'].keys.first] ** (ship.level + 1)).round.to_f %></span></p>
-          
+        <% if upgrade_attrs && ship.level < 5 %>
+          <p><%= I18n.t("ships.upgrade_current_bonus_#{upgrade_attrs.keys.first}") %>: <span class="color-highgreen"><%= ship.level == 0 ? 0.0 : (upgrade_attrs[upgrade_attrs.keys.first] ** ship.level).round.to_f %></span></p>
+          <p><%= I18n.t('ships.upgrade_value_after') %>: <span class="color-highgreen"><%= (upgrade_attrs[upgrade_attrs.keys.first] ** (ship.level + 1)).round.to_f %></span></p>
+
           <p><strong><%= I18n.t('crafting.ressources') %></strong></p>
           <table class="table table-bordered table-striped table-sm mb-3">
-            <% Spaceship.ship_variables[ship.name]['upgrade']['ressources'].each do |k, v| %>
+            <% upgrade_attrs['ressources'].each do |k, v| %>
               <tr>
                 <th><%= Item.get_attribute(k, 'name') %></th>
                 <th><%= Item.find_by(user: current_user, location: current_user.location, loader: k).count rescue 0 %> /  <%= v %>&times;</th>
@@ -26,7 +27,7 @@
         <% end %>
       </div>
       <div class="modal-footer">
-        <% if Spaceship.ship_variables[ship.name]['upgrade'] and ship.level < 5 %>
+        <% if upgrade_attrs && ship.level < 5 %>
           <button class="btn btn-outline-primary upgrade-ship-btn"><%= I18n.t('ships.upgrade') %></button>
         <% end %>
         <button type="button" class="btn btn-secondary" data-dismiss="modal"><%= I18n.t('modal.close') %></button>

--- a/app/views/ships/_upgrade_modal.html.erb
+++ b/app/views/ships/_upgrade_modal.html.erb
@@ -17,7 +17,7 @@
           <table class="table table-bordered table-striped table-sm mb-3">
             <% upgrade_attrs['ressources'].each do |k, v| %>
               <tr>
-                <th><%= Item.get_attribute(k, 'name') %></th>
+                <th><%= Item.get_attribute(k, :name) %></th>
                 <th><%= Item.find_by(user: current_user, location: current_user.location, loader: k).count rescue 0 %> /  <%= v %>&times;</th>
               </tr>
             <% end %>

--- a/app/views/stations/_blueprints.html.erb
+++ b/app/views/stations/_blueprints.html.erb
@@ -40,9 +40,9 @@
       <tbody>
         <% Item.equipment.sort.each do |item| %>
           <tr class="<%= 'color-sec-high' if Blueprint.where(loader: item, user: current_user).present? %>">
-            <td><%= Item.get_attribute(item, 'name') %></td>
-            <td><%= Item.get_attribute(item, 'type') %></td>
-            <td class="color-highgreen"><%= Item.get_attribute(item, 'price') * 20 %> Cr</td>
+            <td><%= Item.get_attribute(item, :name) %></td>
+            <td><%= Item.get_attribute(item, :type) %></td>
+            <td class="color-highgreen"><%= Item.get_attribute(item, :price) * 20 %> Cr</td>
             <td><button class="btn btn-outline-success btn-sm blueprint-modal-btn" data-loader="<%= item %>" data-type="item"><i class="fa fa-dollar-sign"></i></button></td>
           </tr>
         <% end %>

--- a/app/views/stations/_blueprints.html.erb
+++ b/app/views/stations/_blueprints.html.erb
@@ -40,9 +40,9 @@
       <tbody>
         <% Item.equipment.sort.each do |item| %>
           <tr class="<%= 'color-sec-high' if Blueprint.where(loader: item, user: current_user).present? %>">
-            <td><%= get_item_attribute(item, 'name') %></td>
-            <td><%= get_item_attribute(item, 'type') %></td>
-            <td class="color-highgreen"><%= get_item_attribute(item, 'price') * 20 %> Cr</td>
+            <td><%= Item.get_attribute(item, 'name') %></td>
+            <td><%= Item.get_attribute(item, 'type') %></td>
+            <td class="color-highgreen"><%= Item.get_attribute(item, 'price') * 20 %> Cr</td>
             <td><button class="btn btn-outline-success btn-sm blueprint-modal-btn" data-loader="<%= item %>" data-type="item"><i class="fa fa-dollar-sign"></i></button></td>
           </tr>
         <% end %>

--- a/app/views/stations/_factory.html.erb
+++ b/app/views/stations/_factory.html.erb
@@ -71,7 +71,7 @@
             <% else %>
               <th><%= job.loader %></th>
               <td class="w-50">
-                <div class="progress crafting-progress" style="height:21px" data-current="<%= (Spaceship.ship_variables[job.loader]['crafting_duration'] * 60 - (job.completion.to_time - Time.current) / 1.second).round %>" data-max="<%= Spaceship.ship_variables[job.loader]['crafting_duration'] %>">
+                <div class="progress crafting-progress" style="height:21px" data-current="<%= (Spaceship.get_attribute(job.loader, :crafting_duration) * 60 - (job.completion.to_time - Time.current) / 1.second).round %>" data-max="<%= Spaceship.get_attribute(job.loader, :crafting_duration) %>">
                   <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
                 </div>
               </td>
@@ -125,14 +125,14 @@
     var current = $(this).data("current");
     var max = $(this).data("max");
     var progressbar = $(this).children('div');
-    
-    
+
+
     var interval = setInterval(function() {
       current = current + 1
-      var width = current / ((max * 60) / 100) 
+      var width = current / ((max * 60) / 100)
       progressbar.html(Math.round( width * 10) / 10 + '%');
       progressbar.css('width', width + '%');
-      
+
       if (width >= 100) {
         clearInterval(interval);
         progressbar.closest('tr').remove();

--- a/app/views/stations/_factory.html.erb
+++ b/app/views/stations/_factory.html.erb
@@ -43,8 +43,8 @@
       <tbody>
         <% Item.equipment.sort.each_with_index do |item, index| %>
           <tr class="<%= 'color-sec-high' if Blueprint.where(loader: item, user: current_user).present? %> <%= 'color-highgreen' if Blueprint.where(loader: item, efficiency: 0.5, user: current_user).present? %>">
-            <td><%= Item.get_attribute(item, 'name') %></td>
-            <td><%= Item.get_attribute(item, 'type') %></td>
+            <td><%= Item.get_attribute(item, :name) %></td>
+            <td><%= Item.get_attribute(item, :type) %></td>
             <td><button class="btn btn-outline-primary btn-sm factory-modal-btn" data-loader="<%= item %>" data-type="item"><i class="fa fa-cogs"></i></button></td>
           </tr>
         <% end %>
@@ -62,9 +62,9 @@
         <% CraftJob.where(user: current_user, location: current_user.location).each do |job| %>
           <tr>
             <% if job.loader.include? "equipment." %>
-              <th><%= Item.get_attribute(job.loader, 'name') %></th>
+              <th><%= Item.get_attribute(job.loader, :name) %></th>
               <td class="w-50">
-                <div class="progress crafting-progress" style="height:21px" data-current="<%= (Item.get_attribute(job.loader, 'crafting_duration') * 60 - (job.completion.to_time - Time.current) / 1.second).round %>" data-max="<%= Item.get_attribute(job.loader, 'crafting_duration') %>">
+                <div class="progress crafting-progress" style="height:21px" data-current="<%= (Item.get_attribute(job.loader, :crafting_duration) * 60 - (job.completion.to_time - Time.current) / 1.second).round %>" data-max="<%= Item.get_attribute(job.loader, :crafting_duration) %>">
                   <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
                 </div>
               </td>

--- a/app/views/stations/_factory.html.erb
+++ b/app/views/stations/_factory.html.erb
@@ -43,8 +43,8 @@
       <tbody>
         <% Item.equipment.sort.each_with_index do |item, index| %>
           <tr class="<%= 'color-sec-high' if Blueprint.where(loader: item, user: current_user).present? %> <%= 'color-highgreen' if Blueprint.where(loader: item, efficiency: 0.5, user: current_user).present? %>">
-            <td><%= get_item_attribute(item, 'name') %></td>
-            <td><%= get_item_attribute(item, 'type') %></td>
+            <td><%= Item.get_attribute(item, 'name') %></td>
+            <td><%= Item.get_attribute(item, 'type') %></td>
             <td><button class="btn btn-outline-primary btn-sm factory-modal-btn" data-loader="<%= item %>" data-type="item"><i class="fa fa-cogs"></i></button></td>
           </tr>
         <% end %>
@@ -62,9 +62,9 @@
         <% CraftJob.where(user: current_user, location: current_user.location).each do |job| %>
           <tr>
             <% if job.loader.include? "equipment." %>
-              <th><%= get_item_attribute(job.loader, 'name') %></th>
+              <th><%= Item.get_attribute(job.loader, 'name') %></th>
               <td class="w-50">
-                <div class="progress crafting-progress" style="height:21px" data-current="<%= (get_item_attribute(job.loader, 'crafting_duration') * 60 - (job.completion.to_time - Time.current) / 1.second).round %>" data-max="<%= get_item_attribute(job.loader, 'crafting_duration') %>">
+                <div class="progress crafting-progress" style="height:21px" data-current="<%= (Item.get_attribute(job.loader, 'crafting_duration') * 60 - (job.completion.to_time - Time.current) / 1.second).round %>" data-max="<%= Item.get_attribute(job.loader, 'crafting_duration') %>">
                   <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
                 </div>
               </td>

--- a/app/views/stations/_my_ships.html.erb
+++ b/app/views/stations/_my_ships.html.erb
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
       <% user_ships.each do |ship| %>
-        <% ship_vars = Spaceship.ship_variables[ship.name] %>
+        <% ship_vars = ship.get_attributes %>
         <tr class="<%= 'table-light' if current_user.active_spaceship == ship %>">
           <td>
             <% if ship.custom_name %>
@@ -29,10 +29,10 @@
       <% end %>
     </tbody>
   </table>
-  
+
   <% user_ships.each do |ship| %>
-    <% value = Spaceship.ship_variables[ship.name] %>
-    
+    <% value = ship.get_attributes %>
+
     <div class="modal fade" id="insurance-<%= ship.id %>" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -44,7 +44,7 @@
           </div>
           <div class="modal-body">
             <p class="text-center"><%= I18n.t('ships.insurance_text') %></p>
-            
+
             <% if ship.insured %>
               <p class="text-center"><%= I18n.t('ships.ship_already_insured') %></p>
             <% else %>

--- a/app/views/stations/blueprints/_itemmodal.html.erb
+++ b/app/views/stations/blueprints/_itemmodal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= get_item_attribute(item, 'name') %></h5>
+        <h5 class="modal-title"><%= Item.get_attribute(item, 'name') %></h5>
         <button type="button" class="close" data-dismiss="modal">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -12,15 +12,15 @@
         
         <p class="mt-3"><strong><%= I18n.t('crafting.ressources') %> (<%= I18n.t('crafting.at_100_efficiency') %>)</strong></p>
         <table class="table table-bordered table-striped table-sm mb-3">
-          <% get_item_attribute(item, 'crafting').each do |key, value| %>
+          <% Item.get_attribute(item, 'crafting').each do |key, value| %>
             <tr>
-              <th><%= get_item_attribute(key, 'name') %></th>
+              <th><%= Item.get_attribute(key, 'name') %></th>
               <th><%= value %>&times;</th>
             </tr>
           <% end %>
         </table>
         <p><strong><%= I18n.t('crafting.duration') %></strong></p>
-        <% t = get_item_attribute(item, 'crafting_duration') * 60 %>
+        <% t = Item.get_attribute(item, 'crafting_duration') * 60 %>
         <table class="table table-sm table-bordered table-striped">
           <tbody>
             <tr>
@@ -35,7 +35,7 @@
           <tbody>
             <tr>
               <td class="text-center color-highgreen">
-                <%= get_item_attribute(item, 'price') * 20 %> Cr
+                <%= Item.get_attribute(item, 'price') * 20 %> Cr
               </td>
             </tr>
           </tbody>

--- a/app/views/stations/blueprints/_itemmodal.html.erb
+++ b/app/views/stations/blueprints/_itemmodal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= Item.get_attribute(item, 'name') %></h5>
+        <h5 class="modal-title"><%= Item.get_attribute(item, :name) %></h5>
         <button type="button" class="close" data-dismiss="modal">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -12,15 +12,15 @@
         
         <p class="mt-3"><strong><%= I18n.t('crafting.ressources') %> (<%= I18n.t('crafting.at_100_efficiency') %>)</strong></p>
         <table class="table table-bordered table-striped table-sm mb-3">
-          <% Item.get_attribute(item, 'crafting').each do |key, value| %>
+          <% Item.get_attribute(item, :crafting).each do |key, value| %>
             <tr>
-              <th><%= Item.get_attribute(key, 'name') %></th>
+              <th><%= Item.get_attribute(key, :name) %></th>
               <th><%= value %>&times;</th>
             </tr>
           <% end %>
         </table>
         <p><strong><%= I18n.t('crafting.duration') %></strong></p>
-        <% t = Item.get_attribute(item, 'crafting_duration') * 60 %>
+        <% t = Item.get_attribute(item, :crafting_duration) * 60 %>
         <table class="table table-sm table-bordered table-striped">
           <tbody>
             <tr>
@@ -35,7 +35,7 @@
           <tbody>
             <tr>
               <td class="text-center color-highgreen">
-                <%= Item.get_attribute(item, 'price') * 20 %> Cr
+                <%= Item.get_attribute(item, :price) * 20 %> Cr
               </td>
             </tr>
           </tbody>

--- a/app/views/stations/blueprints/_shipmodal.html.erb
+++ b/app/views/stations/blueprints/_shipmodal.html.erb
@@ -14,7 +14,7 @@
         <table class="table table-bordered table-striped table-sm mb-3">
           <% value['crafting'].each do |k, v| %>
             <tr>
-              <th><%= get_item_attribute(k, 'name') %></th>
+              <th><%= Item.get_attribute(k, 'name') %></th>
               <th><%= v %>&times;</th>
             </tr>
           <% end %>

--- a/app/views/stations/blueprints/_shipmodal.html.erb
+++ b/app/views/stations/blueprints/_shipmodal.html.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="modal-body">
         <%= render partial: 'ships/vars', locals: {value: value, key: key} %>
-        
+
         <p><strong><%= I18n.t('crafting.ressources') %> (<%= I18n.t('crafting.at_100_efficiency') %>)</strong></p>
         <table class="table table-bordered table-striped table-sm mb-3">
           <% value['crafting'].each do |k, v| %>
@@ -35,7 +35,7 @@
           <tbody>
             <tr>
               <td class="text-center color-highgreen">
-                <%= Spaceship.ship_variables[key]['price'] * 20 %> Cr
+                <%= Spaceship.get_attribute(key, :price) * 20 %> Cr
               </td>
             </tr>
           </tbody>

--- a/app/views/stations/blueprints/_shipmodal.html.erb
+++ b/app/views/stations/blueprints/_shipmodal.html.erb
@@ -14,7 +14,7 @@
         <table class="table table-bordered table-striped table-sm mb-3">
           <% value['crafting'].each do |k, v| %>
             <tr>
-              <th><%= Item.get_attribute(k, 'name') %></th>
+              <th><%= Item.get_attribute(k, :name) %></th>
               <th><%= v %>&times;</th>
             </tr>
           <% end %>

--- a/app/views/stations/factory/_dismantlemodal.html.erb
+++ b/app/views/stations/factory/_dismantlemodal.html.erb
@@ -8,7 +8,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <h5><%= I18n.t('station.dismantling_item', item: get_item_attribute(item, 'name')) %></h5>
+        <h5><%= I18n.t('station.dismantling_item', item: Item.get_attribute(item, 'name')) %></h5>
         
         <label class="mt-3"><%= I18n.t('station.how_much') %></label>
         <div class="input-group">
@@ -21,9 +21,9 @@
         <label class="mt-3"><%= I18n.t('station.average_amount_received') %></label>
         <table class="table table-sm table-striped table-bordered">
           <tbody>
-            <% get_item_attribute(item, 'crafting').each do |key, value| %>
+            <% Item.get_attribute(item, 'crafting').each do |key, value| %>
               <tr>
-                <td><%= get_item_attribute(key, 'name') %></td>
+                <td><%= Item.get_attribute(key, 'name') %></td>
                 <td class="amount" data-amount="<%= (value * 0.4).round %>"><%= (value * 0.4).round %></td>
               </tr>
             <% end %>

--- a/app/views/stations/factory/_dismantlemodal.html.erb
+++ b/app/views/stations/factory/_dismantlemodal.html.erb
@@ -8,7 +8,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <h5><%= I18n.t('station.dismantling_item', item: Item.get_attribute(item, 'name')) %></h5>
+        <h5><%= I18n.t('station.dismantling_item', item: Item.get_attribute(item, :name)) %></h5>
         
         <label class="mt-3"><%= I18n.t('station.how_much') %></label>
         <div class="input-group">
@@ -21,9 +21,9 @@
         <label class="mt-3"><%= I18n.t('station.average_amount_received') %></label>
         <table class="table table-sm table-striped table-bordered">
           <tbody>
-            <% Item.get_attribute(item, 'crafting').each do |key, value| %>
+            <% Item.get_attribute(item, :crafting).each do |key, value| %>
               <tr>
-                <td><%= Item.get_attribute(key, 'name') %></td>
+                <td><%= Item.get_attribute(key, :name) %></td>
                 <td class="amount" data-amount="<%= (value * 0.4).round %>"><%= (value * 0.4).round %></td>
               </tr>
             <% end %>

--- a/app/views/stations/factory/_itemmodal.html.erb
+++ b/app/views/stations/factory/_itemmodal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= Item.get_attribute(item, 'name') %></h5>
+        <h5 class="modal-title"><%= Item.get_attribute(item, :name) %></h5>
         <button type="button" class="close" data-dismiss="modal">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -13,9 +13,9 @@
         <% if current_user.blueprints.where(loader: item).present? %>
           <p class="mt-3"><strong><%= I18n.t('crafting.ressources') %> (<%= I18n.t('crafting.current_efficiency') %>: <%= (100 / current_user.blueprints.find_by(loader: item).efficiency).round %>%)</strong></p>
           <table class="table table-bordered table-striped table-sm mb-3">
-            <% Item.get_attribute(item, 'crafting').each do |key, value| %>
+            <% Item.get_attribute(item, :crafting).each do |key, value| %>
               <tr>
-                <th><%= Item.get_attribute(key, 'name') %></th>
+                <th><%= Item.get_attribute(key, :name) %></th>
                 <th><%= Item.find_by(user: current_user, location: current_user.location, loader: key).count rescue 0 %> / <%= (value * current_user.blueprints.find_by(loader: item).efficiency).round %>&times;</th>
               </tr>
             <% end %>
@@ -23,9 +23,9 @@
         <% else %>
           <p class="mt-3"><strong><%= I18n.t('crafting.ressources') %> (<%= I18n.t('crafting.at_100_efficiency') %>)</strong></p>
           <table class="table table-bordered table-striped table-sm mb-3">
-            <% Item.get_attribute(item, 'crafting').each do |key, value| %>
+            <% Item.get_attribute(item, :crafting).each do |key, value| %>
               <tr>
-                <th><%= Item.get_attribute(key, 'name') %></th>
+                <th><%= Item.get_attribute(key, :name) %></th>
                 <th><%= value %>&times;</th>
               </tr>
             <% end %>
@@ -33,7 +33,7 @@
         <% end %>
         
         <p><strong><%= I18n.t('crafting.duration') %></strong></p>
-        <% t = Item.get_attribute(item, 'crafting_duration') * 60 %>
+        <% t = Item.get_attribute(item, :crafting_duration) * 60 %>
         <table class="table table-sm table-bordered table-striped">
           <tbody>
             <tr>

--- a/app/views/stations/factory/_itemmodal.html.erb
+++ b/app/views/stations/factory/_itemmodal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= get_item_attribute(item, 'name') %></h5>
+        <h5 class="modal-title"><%= Item.get_attribute(item, 'name') %></h5>
         <button type="button" class="close" data-dismiss="modal">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -13,9 +13,9 @@
         <% if current_user.blueprints.where(loader: item).present? %>
           <p class="mt-3"><strong><%= I18n.t('crafting.ressources') %> (<%= I18n.t('crafting.current_efficiency') %>: <%= (100 / current_user.blueprints.find_by(loader: item).efficiency).round %>%)</strong></p>
           <table class="table table-bordered table-striped table-sm mb-3">
-            <% get_item_attribute(item, 'crafting').each do |key, value| %>
+            <% Item.get_attribute(item, 'crafting').each do |key, value| %>
               <tr>
-                <th><%= get_item_attribute(key, 'name') %></th>
+                <th><%= Item.get_attribute(key, 'name') %></th>
                 <th><%= Item.find_by(user: current_user, location: current_user.location, loader: key).count rescue 0 %> / <%= (value * current_user.blueprints.find_by(loader: item).efficiency).round %>&times;</th>
               </tr>
             <% end %>
@@ -23,9 +23,9 @@
         <% else %>
           <p class="mt-3"><strong><%= I18n.t('crafting.ressources') %> (<%= I18n.t('crafting.at_100_efficiency') %>)</strong></p>
           <table class="table table-bordered table-striped table-sm mb-3">
-            <% get_item_attribute(item, 'crafting').each do |key, value| %>
+            <% Item.get_attribute(item, 'crafting').each do |key, value| %>
               <tr>
-                <th><%= get_item_attribute(key, 'name') %></th>
+                <th><%= Item.get_attribute(key, 'name') %></th>
                 <th><%= value %>&times;</th>
               </tr>
             <% end %>
@@ -33,7 +33,7 @@
         <% end %>
         
         <p><strong><%= I18n.t('crafting.duration') %></strong></p>
-        <% t = get_item_attribute(item, 'crafting_duration') * 60 %>
+        <% t = Item.get_attribute(item, 'crafting_duration') * 60 %>
         <table class="table table-sm table-bordered table-striped">
           <tbody>
             <tr>

--- a/app/views/stations/factory/_shipmodal.html.erb
+++ b/app/views/stations/factory/_shipmodal.html.erb
@@ -15,7 +15,7 @@
           <table class="table table-bordered table-striped table-sm mb-3">
             <% value['crafting'].each do |k, v| %>
               <tr>
-                <th><%= get_item_attribute(k, 'name') %></th>
+                <th><%= Item.get_attribute(k, 'name') %></th>
                 <th><%= Item.find_by(user: current_user, location: current_user.location, loader: k).count rescue 0 %> / <%= (v * current_user.blueprints.find_by(loader: key).efficiency).round  %>&times;</th>
               </tr>
             <% end %>
@@ -25,7 +25,7 @@
           <table class="table table-bordered table-striped table-sm mb-3">
             <% value['crafting'].each do |k, v| %>
               <tr>
-                <th><%= get_item_attribute(k, 'name') %></th>
+                <th><%= Item.get_attribute(k, 'name') %></th>
                 <th><%= v %>&times;</th>
               </tr>
             <% end %>

--- a/app/views/stations/factory/_shipmodal.html.erb
+++ b/app/views/stations/factory/_shipmodal.html.erb
@@ -15,7 +15,7 @@
           <table class="table table-bordered table-striped table-sm mb-3">
             <% value['crafting'].each do |k, v| %>
               <tr>
-                <th><%= Item.get_attribute(k, 'name') %></th>
+                <th><%= Item.get_attribute(k, :name) %></th>
                 <th><%= Item.find_by(user: current_user, location: current_user.location, loader: k).count rescue 0 %> / <%= (v * current_user.blueprints.find_by(loader: key).efficiency).round  %>&times;</th>
               </tr>
             <% end %>
@@ -25,7 +25,7 @@
           <table class="table table-bordered table-striped table-sm mb-3">
             <% value['crafting'].each do |k, v| %>
               <tr>
-                <th><%= Item.get_attribute(k, 'name') %></th>
+                <th><%= Item.get_attribute(k, :name) %></th>
                 <th><%= v %>&times;</th>
               </tr>
             <% end %>

--- a/app/views/stations/market/_list.html.erb
+++ b/app/views/stations/market/_list.html.erb
@@ -30,11 +30,11 @@
               <tr>
                 <td><%= ml.amount %>&times;</td>
                 <% if ml.loader.include? "equipment" %>
-                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, 'name') %></a></td>
+                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, :name) %></a></td>
                 <% else %> 
-                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, 'name') %></span></td>
+                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, :name) %></span></td>
                 <% end %>
-                <td><%= Item.get_attribute(ml.loader, 'type') %></td>
+                <td><%= Item.get_attribute(ml.loader, :type) %></td>
                 <td class="color-highgreen"><%= ml.price %> Cr</td>
                 <td class="mobile-display-none"><%= ml.price * ml.amount %> Cr</td>
                 <td>
@@ -83,11 +83,11 @@
               <tr>
                 <td><%= ml.amount %>&times;</td>
                 <% if ml.loader.include? "equipment" %>
-                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, 'name') %></a></td>
+                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, :name) %></a></td>
                 <% else %> 
-                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, 'name') %></span></td>
+                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, :name) %></span></td>
                 <% end %>
-                <td><%= Item.get_attribute(ml.loader, 'type') %></td>
+                <td><%= Item.get_attribute(ml.loader, :type) %></td>
                 <td class="color-highgreen"><%= ml.price %> Cr</td>
                 <td class="mobile-display-none"><%= ml.price * ml.amount %> Cr</td>
                 <td>
@@ -141,7 +141,7 @@
           <% if ml.ship? %>
             <%= ml.sell? ? I18n.t('modal.sure_buy', name: ml.loader) : I18n.t('modal.sure_sell_of', name: ml.loader) %>
           <% else %>
-            <%= ml.sell? ? I18n.t('modal.sure_buy', name: Item.get_attribute(ml.loader, 'name')) : I18n.t('modal.sure_sell_of', name: Item.get_attribute(ml.loader, 'name')) %>
+            <%= ml.sell? ? I18n.t('modal.sure_buy', name: Item.get_attribute(ml.loader, :name)) : I18n.t('modal.sure_sell_of', name: Item.get_attribute(ml.loader, :name)) %>
           <% end %>
         </div>
         <div class="modal-footer">
@@ -184,7 +184,7 @@
   <script>
     var things = [
       <% Item.items.each do |item| %>
-        "<%= Item.get_attribute(item, 'name') %> (<%= item %>)",
+        "<%= Item.get_attribute(item, :name) %> (<%= item %>)",
       <% end %>
       <% Spaceship.ship_variables.keys.each do |ship| %>
         "<%= ship %>",

--- a/app/views/stations/market/_list.html.erb
+++ b/app/views/stations/market/_list.html.erb
@@ -30,11 +30,11 @@
               <tr>
                 <td><%= ml.amount %>&times;</td>
                 <% if ml.loader.include? "equipment" %>
-                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= get_item_attribute(ml.loader, 'name') %></a></td>
+                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, 'name') %></a></td>
                 <% else %> 
-                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= get_item_attribute(ml.loader, 'name') %></span></td>
+                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, 'name') %></span></td>
                 <% end %>
-                <td><%= get_item_attribute(ml.loader, 'type') %></td>
+                <td><%= Item.get_attribute(ml.loader, 'type') %></td>
                 <td class="color-highgreen"><%= ml.price %> Cr</td>
                 <td class="mobile-display-none"><%= ml.price * ml.amount %> Cr</td>
                 <td>
@@ -83,11 +83,11 @@
               <tr>
                 <td><%= ml.amount %>&times;</td>
                 <% if ml.loader.include? "equipment" %>
-                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= get_item_attribute(ml.loader, 'name') %></a></td>
+                  <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, 'name') %></a></td>
                 <% else %> 
-                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= get_item_attribute(ml.loader, 'name') %></span></td>
+                  <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, 'name') %></span></td>
                 <% end %>
-                <td><%= get_item_attribute(ml.loader, 'type') %></td>
+                <td><%= Item.get_attribute(ml.loader, 'type') %></td>
                 <td class="color-highgreen"><%= ml.price %> Cr</td>
                 <td class="mobile-display-none"><%= ml.price * ml.amount %> Cr</td>
                 <td>
@@ -141,7 +141,7 @@
           <% if ml.ship? %>
             <%= ml.sell? ? I18n.t('modal.sure_buy', name: ml.loader) : I18n.t('modal.sure_sell_of', name: ml.loader) %>
           <% else %>
-            <%= ml.sell? ? I18n.t('modal.sure_buy', name: get_item_attribute(ml.loader, 'name')) : I18n.t('modal.sure_sell_of', name: get_item_attribute(ml.loader, 'name')) %>
+            <%= ml.sell? ? I18n.t('modal.sure_buy', name: Item.get_attribute(ml.loader, 'name')) : I18n.t('modal.sure_sell_of', name: Item.get_attribute(ml.loader, 'name')) %>
           <% end %>
         </div>
         <div class="modal-footer">
@@ -184,7 +184,7 @@
   <script>
     var things = [
       <% Item.items.each do |item| %>
-        "<%= get_item_attribute(item, 'name') %> (<%= item %>)",
+        "<%= Item.get_attribute(item, 'name') %> (<%= item %>)",
       <% end %>
       <% Spaceship.ship_variables.keys.each do |ship| %>
         "<%= ship %>",

--- a/app/views/stations/market/_my_listings.html.erb
+++ b/app/views/stations/market/_my_listings.html.erb
@@ -19,11 +19,11 @@
             <td><%= ml.sell? ? I18n.t('market.sell') : I18n.t('market.buy') %></td>
             <td><%= ml.amount %>&times;</td>
             <% if ml.loader.include? "equipment" %>
-              <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= get_item_attribute(ml.loader, 'name') %></a></td>
+              <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, 'name') %></a></td>
             <% else %> 
-              <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= get_item_attribute(ml.loader, 'name') %></span></td>
+              <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, 'name') %></span></td>
             <% end %>
-            <td><%= get_item_attribute(ml.loader, 'type') %></td>
+            <td><%= Item.get_attribute(ml.loader, 'type') %></td>
             <td class="color-highgreen"><%= ml.price %> Cr</td>
             <td class="mobile-display-none"><%= ml.price * ml.amount %> Cr</td>
             <td>

--- a/app/views/stations/market/_my_listings.html.erb
+++ b/app/views/stations/market/_my_listings.html.erb
@@ -19,11 +19,11 @@
             <td><%= ml.sell? ? I18n.t('market.sell') : I18n.t('market.buy') %></td>
             <td><%= ml.amount %>&times;</td>
             <% if ml.loader.include? "equipment" %>
-              <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, 'name') %></a></td>
+              <td><a href="#" class="equipment-info tier_<%= loaders.index(ml.loader) %>" data-loader="<%= ml.loader %>"><%= Item.get_attribute(ml.loader, :name) %></a></td>
             <% else %> 
-              <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, 'name') %></span></td>
+              <td><span class="tier_<%= loaders.index(ml.loader) %>"><%= Item.get_attribute(ml.loader, :name) %></span></td>
             <% end %>
-            <td><%= Item.get_attribute(ml.loader, 'type') %></td>
+            <td><%= Item.get_attribute(ml.loader, :type) %></td>
             <td class="color-highgreen"><%= ml.price %> Cr</td>
             <td class="mobile-display-none"><%= ml.price * ml.amount %> Cr</td>
             <td>

--- a/app/views/stations/missions/_info.html.erb
+++ b/app/views/stations/missions/_info.html.erb
@@ -22,28 +22,28 @@
     <% if mission.offered? %>
       <% case mission.mission_type %>
       <% when 'delivery' %>
-        <li><%= I18n.t('missions.objective_delivery', amount: mission.mission_amount, name: get_item_attribute(mission.mission_loader, 'name'), weight: get_item_attribute(mission.mission_loader, 'weight'), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
+        <li><%= I18n.t('missions.objective_delivery', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name'), weight: Item.get_attribute(mission.mission_loader, 'weight'), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
       <% when 'combat' %>
         <li><%= I18n.t('missions.objective_combat', system: mission.mission_location.system.name, amount: mission.enemy_amount) %></li>
       <% when 'vip' %>
         <li><%= I18n.t('missions.objective_vip', system: mission.mission_location.system.name, faction: mission.mission_location.faction_name) %></li>
       <% when 'mining' %>
-        <li><%= I18n.t('missions.objective_mining', amount: mission.mission_amount, name: get_item_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_mining', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
       <% when 'market' %>
-        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: get_item_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
       <% end %>
     <% else %>
       <% case mission.mission_type %>
       <% when 'delivery' %>
-        <li><%= I18n.t('missions.objective_delivery_progress', amount: mission.mission_amount, name: get_item_attribute(mission.mission_loader, 'name'), weight: get_item_attribute(mission.mission_loader, 'weight'), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
+        <li><%= I18n.t('missions.objective_delivery_progress', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name'), weight: Item.get_attribute(mission.mission_loader, 'weight'), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
       <% when 'combat' %>
         <li><%= I18n.t('missions.objective_combat_progress', system: mission.mission_location.system.name, amount: mission.enemy_amount) %></li>
       <% when 'vip' %>
         <li><%= I18n.t('missions.objective_vip_progress', system: mission.mission_location.system.name, faction: mission.mission_location.faction_name) %></li>
       <% when 'mining' %>
-        <li><%= I18n.t('missions.objective_mining_progress', amount: mission.mission_amount, name: get_item_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_mining_progress', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
       <% when 'market' %>
-        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: get_item_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/stations/missions/_info.html.erb
+++ b/app/views/stations/missions/_info.html.erb
@@ -22,28 +22,28 @@
     <% if mission.offered? %>
       <% case mission.mission_type %>
       <% when 'delivery' %>
-        <li><%= I18n.t('missions.objective_delivery', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name'), weight: Item.get_attribute(mission.mission_loader, 'weight'), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
+        <li><%= I18n.t('missions.objective_delivery', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, :name), weight: Item.get_attribute(mission.mission_loader, :weight), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
       <% when 'combat' %>
         <li><%= I18n.t('missions.objective_combat', system: mission.mission_location.system.name, amount: mission.enemy_amount) %></li>
       <% when 'vip' %>
         <li><%= I18n.t('missions.objective_vip', system: mission.mission_location.system.name, faction: mission.mission_location.faction_name) %></li>
       <% when 'mining' %>
-        <li><%= I18n.t('missions.objective_mining', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_mining', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, :name)) %></li>
       <% when 'market' %>
-        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, :name)) %></li>
       <% end %>
     <% else %>
       <% case mission.mission_type %>
       <% when 'delivery' %>
-        <li><%= I18n.t('missions.objective_delivery_progress', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name'), weight: Item.get_attribute(mission.mission_loader, 'weight'), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
+        <li><%= I18n.t('missions.objective_delivery_progress', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, :name), weight: Item.get_attribute(mission.mission_loader, :weight), station: Location.find(mission.deliver_to).get_name, system: Location.find(mission.deliver_to).system_name) %></li>
       <% when 'combat' %>
         <li><%= I18n.t('missions.objective_combat_progress', system: mission.mission_location.system.name, amount: mission.enemy_amount) %></li>
       <% when 'vip' %>
         <li><%= I18n.t('missions.objective_vip_progress', system: mission.mission_location.system.name, faction: mission.mission_location.faction_name) %></li>
       <% when 'mining' %>
-        <li><%= I18n.t('missions.objective_mining_progress', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_mining_progress', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, :name)) %></li>
       <% when 'market' %>
-        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, 'name')) %></li>
+        <li><%= I18n.t('missions.objective_market', amount: mission.mission_amount, name: Item.get_attribute(mission.mission_loader, :name)) %></li>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/stations/missions/_popup.html.erb
+++ b/app/views/stations/missions/_popup.html.erb
@@ -31,7 +31,7 @@
               <% if mission.mining? or mission.market? %>
                 <tr>
                   <th><%= I18n.t('missions.item') %></th>
-                  <td><%= Item.get_attribute(mission.mission_loader, 'name') rescue "" %></td>
+                  <td><%= Item.get_attribute(mission.mission_loader, :name) rescue "" %></td>
                 </tr>
                 <tr>
                   <th><%= I18n.t('missions.amount_left') %></th>
@@ -53,7 +53,7 @@
                 </tr>
                 <tr>
                   <th><%= I18n.t('missions.item') %></th>
-                  <td><%= Item.get_attribute(mission.mission_loader, 'name') rescue "" %></td>
+                  <td><%= Item.get_attribute(mission.mission_loader, :name) rescue "" %></td>
                 </tr>
                 <tr>
                   <th><%= I18n.t('missions.amount_left') %></th>

--- a/app/views/stations/missions/_popup.html.erb
+++ b/app/views/stations/missions/_popup.html.erb
@@ -31,7 +31,7 @@
               <% if mission.mining? or mission.market? %>
                 <tr>
                   <th><%= I18n.t('missions.item') %></th>
-                  <td><%= get_item_attribute(mission.mission_loader, 'name') rescue "" %></td>
+                  <td><%= Item.get_attribute(mission.mission_loader, 'name') rescue "" %></td>
                 </tr>
                 <tr>
                   <th><%= I18n.t('missions.amount_left') %></th>
@@ -53,7 +53,7 @@
                 </tr>
                 <tr>
                   <th><%= I18n.t('missions.item') %></th>
-                  <td><%= get_item_attribute(mission.mission_loader, 'name') rescue "" %></td>
+                  <td><%= Item.get_attribute(mission.mission_loader, 'name') rescue "" %></td>
                 </tr>
                 <tr>
                   <th><%= I18n.t('missions.amount_left') %></th>

--- a/app/views/structures/_cargocontainer.html.erb
+++ b/app/views/structures/_cargocontainer.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <% if owner_name != "" %>
+        <% if owner_name.present? %>
           <h5 class="modal-title"><%= I18n.t('structures.container') %> (<%= owner_name %>)</h5>
         <% else %>
           <h5 class="modal-title"><%= I18n.t('structures.container') %></h5>
@@ -36,9 +36,16 @@
             <% end %>
           </tbody>
         </table>
-        
+
         <% structure = Structure.find(container_id) %>
-        <% if structure.user != current_user and structure.structure_type != 'wreck' and !structure.user.in_same_fleet_as(current_user) and structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime and !current_user.system.low? and !current_user.system.wormhole? %>
+        <% police_warning = structure.user != current_user &&
+            structure.structure_type != 'wreck' &&
+            !structure.user.in_same_fleet_as(current_user) &&
+            structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime &&
+            !current_user.system.low? &&
+            !current_user.system.wormhole?
+        %>
+        <% if police_warning  %>
           <p class="color-red"><%= I18n.t('structures.container_police_warning') %></p>
         <% end %>
       </div>

--- a/app/views/structures/_cargocontainer.html.erb
+++ b/app/views/structures/_cargocontainer.html.erb
@@ -38,7 +38,7 @@
         </table>
         
         <% structure = Structure.find(container_id) %>
-        <% if structure.user != current_user and structure.structure_type != 'wreck' and !structure.user.in_same_fleet_as(current_user.id) and structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime and !current_user.system.low? and !current_user.system.wormhole? %>
+        <% if structure.user != current_user and structure.structure_type != 'wreck' and !structure.user.in_same_fleet_as(current_user) and structure.created_at > (DateTime.now.to_time - 10.minutes).to_datetime and !current_user.system.low? and !current_user.system.wormhole? %>
           <p class="color-red"><%= I18n.t('structures.container_police_warning') %></p>
         <% end %>
       </div>

--- a/app/views/users/_info.html.erb
+++ b/app/views/users/_info.html.erb
@@ -36,7 +36,7 @@
                 <%= link_to I18n.t('users.send_mail'), new_game_mail_path(to: user.full_name), class: 'dropdown-item' %>
               </div>
             </div>
-            <% if user.in_same_fleet_as(current_user.id) and current_user.fleet.creator == current_user %>
+            <% if user.in_same_fleet_as(current_user) and current_user.fleet.creator == current_user %>
               <button class="btn btn-outline-danger remove-from-fleet-btn w-33" data-toggle="tooltip" data-placement="top" title="<%= I18n.t('tooltips.remove_from_fleet') %>" data-id="<%= user.id %>">
                 <i class="fa fa-space-shuttle"></i>
               </button>
@@ -47,14 +47,14 @@
             <% end %>
           <% end %>
         </div>
-              
+
         <span class="mb-3">
           <%= I18n.t('bounty.bounty') %>: <span id="user-bounty"><%= user.bounty %></span> Cr&nbsp;&nbsp;
           <button type="button" class="btn btn-outline-primary btn-sm add-bounty-btn">
             <i class="fa fa-plus"></i>
           </button>
         </span>
-            
+
         <div class="bg-fade-light" style="display:none;" id="bountyModal">
           <div class="input-group">
             <input type="text" class="form-control" placeholder="<%= I18n.t('bounty.bounty_placeholder') %>" id="bounty-input">
@@ -63,7 +63,7 @@
             </div>
           </div>
         </div>
-        
+
         <ul class="nav nav-tabs mt-3" role="tablist">
           <li class="nav-item">
             <a class="nav-link active" data-toggle="tab" data-target="#bio-user-info" href="#0" role="tab"><%= I18n.t('users.bio') %></a>
@@ -101,7 +101,7 @@
           <% if current_user.admin || current_user.chat_mod %>
             <div class="tab-pane fade" id="about-user-ship" role="tabpanel">
               <div class="mt-5px">
-                <%= render partial: 'ships/vars', locals: {value: Spaceship.ship_variables[user.active_spaceship.name], key: user.active_spaceship.name} %>
+                <%= render partial: 'ships/vars', locals: {value: user.active_spaceship.get_attributes(), key: user.active_spaceship.name} %>
               </div>
             </div>
             <div class="tab-pane fade" id="admin" role="tabpanel">
@@ -114,7 +114,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="modal fade" id="bountyModal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
       <div class="modal-content">

--- a/app/workers/equipment_worker.rb
+++ b/app/workers/equipment_worker.rb
@@ -197,7 +197,7 @@ class EquipmentWorker
   def call_police(player)
     player_id = player.id
 
-    if !player.system.low? && !player.system.wormhole? && Npc.where(npc_type: 'police', target: player_id).empty? && !player.target.in_same_fleet_as(player_id)
+    if !player.system.low? && !player.system.wormhole? && !Npc.police.targeting_user(player).exists? && !player.target.in_same_fleet_as(player)
       if player.system.security_status == 'high'
         PoliceWorker.perform_async(player_id, 2)
       else

--- a/app/workers/mining_worker.rb
+++ b/app/workers/mining_worker.rb
@@ -72,7 +72,7 @@ class MiningWorker
       end
 
       # Log
-      ac_server.broadcast("player_#{player_id}", method: 'log', text: I18n.t('log.you_mined_from_asteroid', amount: mining_amount, ore: get_item_attribute("asteroid.#{asteroid.asteroid_type}_ore", 'name').downcase))
+      ac_server.broadcast("player_#{player_id}", method: 'log', text: I18n.t('log.you_mined_from_asteroid', amount: mining_amount, ore: Item.get_attribute("asteroid.#{asteroid.asteroid_type}_ore", 'name').downcase))
 
       # Get enemy
       EnemyWorker.perform_async(nil, player.location.id) if rand(10) == 9

--- a/app/workers/mining_worker.rb
+++ b/app/workers/mining_worker.rb
@@ -72,7 +72,7 @@ class MiningWorker
       end
 
       # Log
-      ac_server.broadcast("player_#{player_id}", method: 'log', text: I18n.t('log.you_mined_from_asteroid', amount: mining_amount, ore: Item.get_attribute("asteroid.#{asteroid.asteroid_type}_ore", 'name').downcase))
+      ac_server.broadcast("player_#{player_id}", method: 'log', text: I18n.t('log.you_mined_from_asteroid', amount: mining_amount, ore: Item.get_attribute("asteroid.#{asteroid.asteroid_type}_ore", :name).downcase))
 
       # Get enemy
       EnemyWorker.perform_async(nil, player.location.id) if rand(10) == 9

--- a/app/workers/police_worker.rb
+++ b/app/workers/police_worker.rb
@@ -12,7 +12,7 @@ class PoliceWorker
     return unless police if npc_id
 
     if npc_id == nil
-      police = Npc.create(npc_type: 'police', target: player.id, name: generate_name)
+      police = Npc.create(npc_type: :police, target_user: player, name: generate_name)
 
       PoliceWorker.perform_in(seconds.second, player_id, seconds, police.id) && (return)
     end

--- a/config/variables/factions.yml
+++ b/config/variables/factions.yml
@@ -1,18 +1,18 @@
-1:
+"1":
   placeholder: leviathan.png
   ticker: HEL
   damage_amplifier: 1.1
   defense_amplifier: 1
   storage_amplifier: 1
 
-2:
+"2":
   placeholder: spectrum.png
   ticker: CAL
   damage_amplifier: 1
   defense_amplifier: 1.1
   storage_amplifier: 1
 
-3:
+"3":
   placeholder: escorial.png
   ticker: COR
   damage_amplifier: 1

--- a/lib/tasks/economy.rake
+++ b/lib/tasks/economy.rake
@@ -2,15 +2,6 @@ namespace :economy do
 
   desc "Redo the economy"
   task redo: :environment do
-    def get_item_attribute(loader, attribute)
-      atty = loader.split(".")
-      out = Item.item_variables[atty[0]]
-      loader.count('.').times do |i|
-        out = out[atty[i + 1]]
-      end
-      out[attribute] rescue nil
-    end
-
     MarketListing.where(user: nil).destroy_all
     noise = Perlin::Noise.new 1, seed: 1000
     noise_level = [0, 1, 2, 3, 4, 5, 6, 7, 8 , 9, 8, 7, 6, 5, 4, 3, 2, 1]
@@ -25,7 +16,7 @@ namespace :economy do
         next if item == "asteroid.lunarium_ore"
         rand(0..1).times do
           rand(3..15).times do
-            MarketListing.create(loader: item, location: location, listing_type: 'item', price: (get_item_attribute(item, 'price') * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
+            MarketListing.create(loader: item, location: location, listing_type: 'item', price: (Item.get_attribute(item, 'price') * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
           end
         end
       end

--- a/lib/tasks/economy.rake
+++ b/lib/tasks/economy.rake
@@ -16,7 +16,7 @@ namespace :economy do
         next if item == "asteroid.lunarium_ore"
         rand(0..1).times do
           rand(3..15).times do
-            MarketListing.create(loader: item, location: location, listing_type: 'item', price: (Item.get_attribute(item, 'price') * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
+            MarketListing.create(loader: item, location: location, listing_type: 'item', price: (Item.get_attribute(item, :price) * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
           end
         end
       end

--- a/runner/crafting_job.rb
+++ b/runner/crafting_job.rb
@@ -10,7 +10,7 @@ while time < 50 do
       if job.loader.include? "equipment."
         Item.give_to_user(loader: job.loader, user: job.user, location: job.location, amount: 1)
       else
-        Spaceship.create(user_id: job.user.id, name: job.loader, hp: Spaceship.get_attribute(job.loader,:hp), location: job.location)
+        Spaceship.create(user_id: job.user.id, name: job.loader, hp: Spaceship.get_attribute(job.loader, :hp), location: job.location)
       end
 
       # Increase Effiency

--- a/runner/crafting_job.rb
+++ b/runner/crafting_job.rb
@@ -10,7 +10,7 @@ while time < 50 do
       if job.loader.include? "equipment."
         Item.give_to_user(loader: job.loader, user: job.user, location: job.location, amount: 1)
       else
-        Spaceship.create(user_id: job.user.id, name: job.loader, hp: Spaceship.ship_variables[job.loader]['hp'], location: job.location)
+        Spaceship.create(user_id: job.user.id, name: job.loader, hp: Spaceship.get_attribute(job.loader,:hp), location: job.location)
       end
 
       # Increase Effiency

--- a/runner/economy_redo.rb
+++ b/runner/economy_redo.rb
@@ -68,7 +68,7 @@ Location.where(location_type: 'station', player_market: false).order(Arel.sql("R
       next if item == "asteroid.lunarium_ore"
       rand(0..1).times do
         rand(3..6).times do
-          MarketListing.create(loader: item, location: location, listing_type: 'item', price: (Item.get_attribute(item, 'price') * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
+          MarketListing.create(loader: item, location: location, listing_type: 'item', price: (Item.get_attribute(item, :price) * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
         end
       end
     end

--- a/runner/economy_redo.rb
+++ b/runner/economy_redo.rb
@@ -1,4 +1,4 @@
-def get_item_attribute(loader, attribute)
+def Item.get_attribute(loader, attribute)
   atty = loader.split(".")
   out = Item.item_variables[atty[0]]
   loader.count('.').times do |i|
@@ -68,7 +68,7 @@ Location.where(location_type: 'station', player_market: false).order(Arel.sql("R
       next if item == "asteroid.lunarium_ore"
       rand(0..1).times do
         rand(3..6).times do
-          MarketListing.create(loader: item, location: location, listing_type: 'item', price: (get_item_attribute(item, 'price') * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
+          MarketListing.create(loader: item, location: location, listing_type: 'item', price: (Item.get_attribute(item, 'price') * rabat * rand(0.98..1.02)).round, amount: rand(10..30))
         end
       end
     end

--- a/runner/temp_remove_equipment.rb
+++ b/runner/temp_remove_equipment.rb
@@ -7,18 +7,18 @@ Spaceship.all.each do |ship|
       utility_amount = utility_amount + 1 if equipment.get_attribute('slot_type') == "utility"
    end
 
-   if main_amount > Spaceship.ship_variables[ship.name]['main_equipment_slots']
+   if main_amount > ship.get_attribute(:main_equipment_slots)
      ship.get_equipped_equipment.each do |equipment|
-       if (equipment.get_attribute('slot_type') == "main") && (main_amount > Spaceship.ship_variables[ship.name]['main_equipment_slots'])
+       if (equipment.get_attribute('slot_type') == "main") && (main_amount > ship.get_attribute(:main_equipment_slots))
          equipment.update_columns(equipped: false)
           main_amount = main_amount - 1
        end
      end
    end
 
-   if utility_amount > Spaceship.ship_variables[ship.name]['utility_equipment_slots']
+   if utility_amount > ship.get_attribute(:utility_equipment_slots)
      ship.get_equipped_equipment.each do |equipment|
-       if (equipment.get_attribute('slot_type') == "utility") && (utility_amount > Spaceship.ship_variables[ship.name]['utility_equipment_slots'])
+       if (equipment.get_attribute('slot_type') == "utility") && (utility_amount > ship.get_attribute(:utility_equipment_slots))
          equipment.update_columns(equipped: false)
           utility_amount = utility_amount - 1
        end

--- a/spec/controllers/equipment_controller_spec.rb
+++ b/spec/controllers/equipment_controller_spec.rb
@@ -2,120 +2,130 @@ require 'rails_helper'
 
 RSpec.describe EquipmentController, type: :controller do
   context 'with login' do
+    let(:user) { create :user_with_faction, docked: true }
+
     before (:each) do
-      @user = FactoryBot.create(:user_with_faction, docked: true)
-      sign_in @user
+      sign_in user
     end
 
     describe 'POST update' do
-      before(:each) do
-        @equipment1 = FactoryBot.create(:item, loader: "equipment.weapons.laser_gatling", spaceship: @user.active_spaceship, equipped: false)
-        @equipment2 = FactoryBot.create(:item, loader: "equipment.storage.small_black_hole", spaceship: @user.active_spaceship, equipped: false)
-      end
+      let!(:equipment1) { create :item,
+          loader: "equipment.weapons.laser_gatling",
+          spaceship: user.active_spaceship,
+          equipped: false
+      }
+      let!(:equipment2) { create :item,
+          loader: "equipment.storage.small_black_hole",
+          spaceship: user.active_spaceship,
+          equipped: false
+      }
 
       it 'should update equip status of items on main slot' do
-        post :update, params: { ids: { "main": [@equipment1.loader] } }
-        expect(response.status).to eq(200)
-        expect(@equipment1.reload.equipped).to be_truthy
+        post :update, params: { ids: { "main": [equipment1.loader] } }
+        expect(response).to have_http_status(:ok)
+        expect(equipment1.reload.equipped).to eq(true)
       end
 
       it 'should update not equip status of items on utility slot if ship has no slots' do
-        post :update, params: { ids: { "utility": [@equipment2.loader] } }
-        expect(response.status).to eq(400)
-        expect(@equipment2.reload.equipped).to be_falsey
+        post :update, params: { ids: { "utility": [equipment2.loader] } }
+        expect(response).to have_http_status(:bad_request)
+        expect(equipment2.reload.equipped).to eq(false)
       end
 
       it 'should update not equip status of items on utility slot if ship has no slots' do
-        @equipment3 = FactoryBot.create(:item, loader: "equipment.weapons.laser_gatling", spaceship: @user.active_spaceship, equipped: false)
-        @equipment4 = FactoryBot.create(:item, loader: "equipment.weapons.laser_gatling", spaceship: @user.active_spaceship, equipped: false)
-        post :update, params: { ids: { "main": [@equipment1.loader, @equipment3.loader, @equipment4.loader] } }
-        expect(response.status).to eq(400)
-        expect(@equipment1.reload.equipped).to be_truthy
-        expect(@equipment4.reload.equipped).to be_falsey
+        equipment3 = create(:item, loader: "equipment.weapons.laser_gatling", spaceship: user.active_spaceship, equipped: false)
+        equipment4 = create(:item, loader: "equipment.weapons.laser_gatling", spaceship: user.active_spaceship, equipped: false)
+
+        post :update, params: { ids: { "main": [equipment1.loader, equipment3.loader, equipment4.loader] } }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(equipment1.reload.equipped).to eq(true)
+        expect(equipment4.reload.equipped).to eq(false)
       end
 
       it 'should update equip status of items on utility slot if ship has slots' do
-        ship = FactoryBot.create(:spaceship, name: "Valadria", user: @user)
-        @user.update_columns(active_spaceship_id: ship.id)
-        @equipment2.update_columns(spaceship_id: ship.id)
-        post :update, params: { ids: { "utility": [@equipment2.loader] } }
-        expect(response.status).to eq(200)
-        expect(@equipment2.reload.equipped).to be_truthy
+        ship = create(:spaceship, name: "Valadria", user: user)
+        user.update(active_spaceship: ship)
+        equipment2.update(spaceship: ship)
+        post :update, params: { ids: { "utility": [equipment2.loader] } }
+        expect(response).to have_http_status(:ok)
+        expect(equipment2.reload.equipped).to eq(true)
       end
 
       it 'should not update equip status of items if not docked' do
-        @user.update_columns(docked: false)
-        post :update, params: { ids: { "main": [@equipment1.loader] } }
-        expect(response.status).to eq(400)
-        expect(@equipment1.reload.equipped).to be_falsey
+        user.update(docked: false)
+        post :update, params: { ids: { "main": [equipment1.loader] } }
+        expect(response).to have_http_status(:bad_request)
+        expect(equipment1.reload.equipped).to eq(false)
       end
 
       it 'should update equip status of trying to fit wrong slot but instead fitting it in the right slot' do
-        post :update, params: { ids: { "utility": [@equipment1.loader] } }
-        expect(response.status).to eq(200)
-        expect(@equipment1.reload.equipped).to be_truthy
+        post :update, params: { ids: { "utility": [equipment1.loader] } }
+        expect(response).to have_http_status(:ok)
+        expect(equipment1.reload.equipped).to eq(true)
       end
 
       it 'should not update equip status of trying to fit wrong slot' do
-        post :update, params: { ids: { "main": [@equipment2.loader] } }
-        expect(response.status).to eq(400)
-        expect(@equipment2.reload.equipped).to be_falsey
+        post :update, params: { ids: { "main": [equipment2.loader] } }
+        expect(response).to have_http_status(:bad_request)
+        expect(equipment2.reload.equipped).to eq(false)
       end
 
       it 'should O.K but not update equipment on random params given' do
-        post :update, params: { ids: { "blub": [@equipment2.loader] } }
-        expect(response.status).to eq(200)
-        expect(@equipment2.reload.equipped).to be_falsey
+        post :update, params: { ids: { "blub": [equipment2.loader] } }
+        expect(response).to have_http_status(:ok)
+        expect(equipment2.reload.equipped).to eq(false)
       end
 
       it 'should fail if item is not in spaceship' do
-        @equipment1.update_columns(spaceship_id: nil)
-        post :update, params: { ids: { "main": [@equipment1.loader] } }
-        expect(response.status).to eq(400)
-        expect(@equipment1.reload.equipped).to be_falsey
+        equipment1.update(spaceship: nil)
+        post :update, params: { ids: { "main": [equipment1.loader] } }
+        expect(response).to have_http_status(:bad_request)
+        expect(equipment1.reload.equipped).to eq(false)
       end
 
       it 'should unequip items no listed in params' do
-        post :update, params: { ids: { "main": [@equipment1.loader] } }
-        expect(response.status).to eq(200)
-        expect(@equipment1.reload.equipped).to be_truthy
+        post :update, params: { ids: { "main": [equipment1.loader] } }
+        expect(response).to have_http_status(:ok)
+        expect(equipment1.reload.equipped).to eq(true)
         post :update
-        expect(response.status).to eq(200)
-        expect(Item.where(loader: @equipment1.loader, spaceship: @user.active_spaceship).count).to eq(1)
+        expect(response).to have_http_status(:ok)
+        expect(Item.where(loader: equipment1.loader, spaceship: user.active_spaceship).count).to eq(1)
       end
     end
 
     describe 'POST switch' do
+      let(:user2) { create :user_with_faction }
+      let!(:equipment1) { create(:item, loader: "equipment.weapons.laser_gatling", spaceship: user.active_spaceship, equipped: true) }
+
       before(:each) do
-        user2 = FactoryBot.create(:user_with_faction)
-        @user.update_columns(docked: false, target_id: user2.id)
-        @equipment1 = FactoryBot.create(:item, loader: "equipment.weapons.laser_gatling", spaceship: @user.active_spaceship, equipped: true)
+        user.update(docked: false, target: user2)
       end
 
       it 'should activate item on ship' do
-        post :switch, params: { id: @equipment1.id }
-        expect(response.status).to eq(200)
-        expect(@equipment1.reload.active).to be_truthy
+        post :switch, params: { id: equipment1.id }
+        expect(response).to have_http_status(:ok)
+        expect(equipment1.reload.active).to eq(true)
       end
 
       it 'should activate item on ship and start equipment worker' do
-        post :switch, params: { id: @equipment1.id }
-        expect(response.status).to eq(200)
-        expect(@equipment1.reload.active).to be_truthy
+        post :switch, params: { id: equipment1.id }
+        expect(response).to have_http_status(:ok)
+        expect(equipment1.reload.active).to eq(true)
         expect(EquipmentWorker.jobs.size).to eq(1)
       end
 
       it 'should not activate item on ship if no params' do
         post :switch
-        expect(response.status).to eq(400)
-        expect(@equipment1.reload.active).to be_falsey
+        expect(response).to have_http_status(:bad_request)
+        expect(equipment1.reload.active).to eq(false)
       end
 
       it 'should deactivate active item on ship' do
-        @equipment1.update_columns(active: true)
-        post :switch, params: { id: @equipment1.id }
-        expect(response.status).to eq(200)
-        expect(@equipment1.reload.active).to be_falsey
+        equipment1.update(active: true)
+        post :switch, params: { id: equipment1.id }
+        expect(response).to have_http_status(:ok)
+        expect(equipment1.reload.active).to eq(false)
       end
     end
   end

--- a/spec/controllers/stations_controller_spec.rb
+++ b/spec/controllers/stations_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe StationsController, type: :controller do
 
   context 'with login' do
     let(:station) { Location.where(location_type: :station).first }
-    let!(:user) { create :user_with_faction, location: station}
+    let!(:user) { create :user_with_faction, location: station }
 
     before(:each) do
       sign_in user

--- a/spec/controllers/stations_controller_spec.rb
+++ b/spec/controllers/stations_controller_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe StationsController, type: :controller do
     describe 'GET index' do
       it 'should redirect when user not logged in' do
         get :index
-        expect(response.code).to eq('302')
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -13,7 +12,6 @@ RSpec.describe StationsController, type: :controller do
     describe 'POST dock' do
       it 'should redirect when user not logged in' do
         post :dock
-        expect(response.code).to eq('302')
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -21,7 +19,6 @@ RSpec.describe StationsController, type: :controller do
     describe 'POST undock' do
       it 'should redirect when user not logged in' do
         post :undock
-        expect(response.code).to eq('302')
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -29,7 +26,6 @@ RSpec.describe StationsController, type: :controller do
     describe 'POST store' do
       it 'should redirect when user is not logged in' do
         post :store
-        expect(response.code).to eq('302')
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -37,34 +33,35 @@ RSpec.describe StationsController, type: :controller do
     describe 'POST load' do
       it 'should redirect when user is not logged in' do
         post :load
-        expect(response.code).to eq('302')
         expect(response).to redirect_to(new_user_session_path)
       end
     end
   end
 
   context 'with login' do
+    let(:station) { Location.where(location_type: :station).first }
+    let!(:user) { create :user_with_faction, location: station}
+
     before(:each) do
-      @user = FactoryBot.create(:user_with_faction, location: Location.where(location_type: :station).first)
-      sign_in @user
+      sign_in user
     end
 
     describe 'GET index' do
       it 'should display index when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index
         expect(response.code).to eq('200')
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'overview' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_overview')
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'my_ships' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_my_ships')
@@ -72,42 +69,42 @@ RSpec.describe StationsController, type: :controller do
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'active_ship' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_active_ship')
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'bounty_office' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_bounty_office')
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'storage' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_storage')
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'factory' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_factory')
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'market' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_market')
       end
 
       it 'should display tab when user is docked' do
-        @user.update_columns(docked: true)
+        user.update(docked: true)
         get :index, params: { tab: 'missions' }
         expect(response.code).to eq('200')
         expect(response).to render_template('stations/_missions')
@@ -123,131 +120,130 @@ RSpec.describe StationsController, type: :controller do
 
     describe 'POST dock' do
       it 'should set user to docked if at station' do
-        @user.update_columns(location_id: Location.where(location_type: 'station').first.id)
         post :dock
-        expect(response.code).to eq('204')
-        expect(@user.reload.docked).to be_truthy
+        expect(response).to have_http_status(:no_content)
+        expect(user.reload.docked).to eq(true)
       end
 
       it 'should do nothing when user not at station' do
         post :dock
-        expect(response.code).to eq('204')
-        expect(@user.docked).to be_falsey
+        expect(response).to have_http_status(:no_content)
+        expect(user.docked).to eq(false)
       end
 
       it 'should do nothing when police is engaged' do
-        @user.update_columns(location_id: Location.where(location_type: 'station').first.id)
-        FactoryBot.create(:npc_police, target: @user.id)
+        FactoryBot.create(:npc_police, target_user: user)
         post :dock
-        expect(response.code).to eq('400')
-        expect(@user.docked).to be_falsey
+        expect(response).to have_http_status(:bad_request)
+        expect(user.docked).to eq(false)
       end
 
       it 'should remove user as target of other users' do
-        @user.update_columns(location_id: Location.where(location_type: 'station').first.id)
         user2 = FactoryBot.create(:user_with_faction)
-        user2.update_columns(target_id: @user.id)
+        user2.update(target: user)
 
-        expect(user2.target_id).to eq(@user.id)
+        expect(user2.target).to eq(user)
         post :dock
-        expect(response.code).to eq('204')
-        expect(@user.reload.docked).to be_truthy
+        expect(response).to have_http_status(:no_content)
+        expect(user.reload.docked).to eq(true)
         expect(user2.reload.target_id).to eq(nil)
       end
 
       it 'should refuse request if user standing below or eq -10 with faction' do
-        @user.update_columns(location_id: Location.where(location_type: 'station').where(faction_id: 1).first.id)
-        @user.update_columns(reputation_1: -10)
+        faction_station = Location.where(location_type: 'station').where(faction_id: 1).first
+        user.update(location: faction_station)
+        user.update(reputation_1: -10)
         post :dock
-        expect(response.code).to eq('400')
-        expect(@user.reload.docked).to be_falsey
+        expect(response).to have_http_status(:bad_request)
+        expect(user.reload.docked).to eq(false)
       end
     end
 
     describe 'POST undock' do
       it 'should set user to docked false if at station and docked' do
-        @user.update_columns(location_id: Location.where(location_type: 'station').first.id, docked: true)
+        user.update(docked: true)
         post :undock
-        expect(response.code).to eq('204')
-        expect(@user.docked).to eq(true)
+        expect(response).to have_http_status(:no_content)
+        expect(user.docked).to eq(true)
       end
 
       it 'should do nothing when user is not docked' do
         post :undock
-        expect(response.code).to eq('204')
-        expect(@user.docked).to eq(false)
+        expect(response).to have_http_status(:no_content)
+        expect(user.docked).to eq(false)
       end
     end
 
     describe 'POST store' do
       before(:each) do
-        @user.update_columns(location_id: Location.where(location_type: 'station').first.id, docked: true)
-        Item.create(loader: 'test', spaceship: @user.active_spaceship, equipped: false, count: 3)
+        user.update(docked: true)
+        Item.create(loader: 'test', spaceship: user.active_spaceship, equipped: false, count: 3)
       end
 
       it 'should store items in station' do
-        expect(@user.active_spaceship.get_weight).to eq(3)
+        expect(user.active_spaceship.get_weight).to eq(3)
         post :store, params: { loader: 'test', amount: 3 }
         expect(response.code).to eq('200')
-        expect(@user.active_spaceship.get_weight).to eq(0)
-        expect(@user.location.items.count).to eq(1)
-        expect(@user.location.items.first.count).to eq(3)
+        expect(user.active_spaceship.get_weight).to eq(0)
+        expect(user.location.items.count).to eq(1)
+        expect(user.location.items.first.count).to eq(3)
       end
 
       it 'should not store more items in station than player has' do
-        expect(@user.active_spaceship.get_weight).to eq(3)
+        expect(user.active_spaceship.get_weight).to eq(3)
         post :store, params: { loader: 'test', amount: 4 }
-        expect(response.code).to eq('400')
-        expect(@user.active_spaceship.get_weight).to eq(3)
-        expect(@user.location.items.count).to eq(0)
+        expect(response).to have_http_status(:bad_request)
+        expect(user.active_spaceship.get_weight).to eq(3)
+        expect(user.location.items.count).to eq(0)
       end
 
       it 'should not store less items in station than 0' do
-        expect(@user.active_spaceship.get_weight).to eq(3)
+        expect(user.active_spaceship.get_weight).to eq(3)
         post :store, params: { loader: 'test', amount: -1 }
-        expect(response.code).to eq('400')
-        expect(@user.active_spaceship.get_weight).to eq(3)
-        expect(@user.location.items.count).to eq(0)
+        expect(response).to have_http_status(:bad_request)
+        expect(user.active_spaceship.get_weight).to eq(3)
+        expect(user.location.items.count).to eq(0)
       end
     end
 
     describe 'POST load' do
+
       before(:each) do
-        @user.update_columns(location_id: Location.where(location_type: 'station').first.id, docked: true)
-        Item.create(loader: 'test', user: @user, location: @user.location, equipped: false, count: 3)
+        user.update(docked: true)
+        Item.create(loader: 'test', user: user, location: user.location, equipped: false, count: 3)
       end
 
       it 'should store items in ship' do
-        expect(@user.location.items.count).to eq(1)
+        expect(user.location.items.count).to eq(1)
         post :load, params: { loader: 'test', amount: 3 }
         expect(response.code).to eq('200')
-        expect(@user.active_spaceship.get_weight).to eq(3)
-        expect(@user.location.items.count).to eq(0)
+        expect(user.active_spaceship.get_weight).to eq(3)
+        expect(user.location.items.count).to eq(0)
       end
 
       it 'should not store more items in ship than player has' do
-        expect(@user.location.items.count).to eq(1)
+        expect(user.location.items.count).to eq(1)
         post :load, params: { loader: 'test', amount: 4 }
-        expect(response.code).to eq('400')
-        expect(@user.active_spaceship.get_weight).to eq(0)
-        expect(@user.location.items.count).to eq(1)
+        expect(response).to have_http_status(:bad_request)
+        expect(user.active_spaceship.get_weight).to eq(0)
+        expect(user.location.items.count).to eq(1)
       end
 
       it 'should not store less items in ship than 0' do
-        expect(@user.location.items.count).to eq(1)
+        expect(user.location.items.count).to eq(1)
         post :load, params: { loader: 'test', amount: -1 }
-        expect(response.code).to eq('400')
-        expect(@user.active_spaceship.get_weight).to eq(0)
-        expect(@user.location.items.count).to eq(1)
+        expect(response).to have_http_status(:bad_request)
+        expect(user.active_spaceship.get_weight).to eq(0)
+        expect(user.location.items.count).to eq(1)
       end
 
       it 'should not store more items in ship than ship can carry' do
-        Item.create(loader: 'test', user: @user, location: @user.location, count: 10)
-        expect(@user.location.items.count).to eq(2)
+        Item.create(loader: 'test', user: user, location: user.location, count: 10)
+        expect(user.location.items.count).to eq(2)
         post :load, params: { loader: 'test', amount: 13 }
-        expect(response.code).to eq('400')
-        expect(@user.active_spaceship.get_weight).to eq(0)
-        expect(@user.location.items.count).to eq(2)
+        expect(response).to have_http_status(:bad_request)
+        expect(user.active_spaceship.get_weight).to eq(0)
+        expect(user.location.items.count).to eq(2)
       end
     end
   end

--- a/spec/factories/npcs.rb
+++ b/spec/factories/npcs.rb
@@ -1,10 +1,9 @@
 FactoryBot.define do
   factory :npc do
-    npc_type { 0 }
-    location { nil }
+    npc_type { :enemy }
 
     factory :npc_police do
-      npc_type { 1 }
+      npc_type { :police }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,14 +18,4 @@ describe ApplicationHelper do
       expect(online_status(user)).to include("ago")
     end
   end
-
-  describe 'get_item_attribute' do
-    it 'should return attribute of item' do
-      expect(get_item_attribute('test', 'weight')).to eq(1)
-    end
-
-    it 'should return nil attribute of item' do
-      expect(get_item_attribute('hudaf', 'weight')).to eq(nil)
-    end
-  end
 end

--- a/spec/models/faction_spec.rb
+++ b/spec/models/faction_spec.rb
@@ -15,26 +15,32 @@ describe Faction do
     end
 
     describe 'Functions' do
+      let(:faction) { Faction.first }
+
       describe 'get_attribute' do
         it 'should return attribute' do
-          expect(Faction.first.get_attribute('ticker')).to eq('HEL')
+          expect(faction.get_attribute('ticker')).to eq('HEL')
         end
 
         it 'should return nil' do
-          expect(Faction.first.get_attribute('noot')).to eq(nil)
+          expect(faction.get_attribute('noot')).to eq(nil)
+        end
+
+        it 'should return default' do
+          expect(faction.get_attribute('noot', default: true)).to eq(true)
         end
       end
 
       describe 'get_ticker' do
         it 'should return ticker' do
-          expect(Faction.first.get_ticker).to eq('[HEL]')
+          expect(faction.get_ticker).to eq('[HEL]')
         end
       end
 
       describe 'get_rank' do
         it 'should return rank of particular user' do
           user = FactoryBot.create(:user_with_faction, reputation_1: -5, reputation_2: -5, reputation_3: -5)
-          expect(Faction.first.get_rank(user)).to eq("name" => "Shunned", "reputation" => -5.0, "type" => 3, "unlocks" => [])
+          expect(faction.get_rank(user)).to eq("name" => "Shunned", "reputation" => -5.0, "type" => 3, "unlocks" => [])
         end
       end
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -14,11 +14,11 @@ describe Item do
     describe 'Functions' do
       describe 'get_attribute' do
         it 'should return attribute of item' do
-          expect(Item.get_attribute('test', 'weight')).to eq(1)
+          expect(Item.get_attribute('test', :weight)).to eq(1)
         end
 
         it 'should return nil attribute of item' do
-          expect(Item.get_attribute('hudaf', 'weight')).to eq(nil)
+          expect(Item.get_attribute('hudaf', :weight)).to eq(nil)
         end
 
         it 'should return default if attribute not defined' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -14,42 +14,51 @@ describe Item do
     describe 'Functions' do
       describe 'get_attribute' do
         it 'should return attribute of item' do
-          @item = Item.create(loader: 'asteroid.iron_ore', user: FactoryBot.create(:user_with_faction))
-          expect(@item.get_attribute('weight')).to eq(1)
+          expect(Item.get_attribute('test', 'weight')).to eq(1)
+        end
+
+        it 'should return nil attribute of item' do
+          expect(Item.get_attribute('hudaf', 'weight')).to eq(nil)
+        end
+
+        it 'should return default if attribute not defined' do
+          expect(Item.get_attribute('hudaf', 'weight', default: 10)).to eq(10)
+        end
+
+        it 'should return attribute of item' do
+          item = Item.new(loader: 'asteroid.iron_ore', user: FactoryBot.create(:user_with_faction))
+          expect(item.get_attribute('weight')).to eq(1)
         end
       end
 
       describe 'remove from user' do
-        before(:each) do
-          @user = FactoryBot.create(:user_with_faction)
-          @item = Item.create(loader: 'asteroid.iron_ore', user: @user, location: @user.location)
-        end
+        let(:user) { create :user_with_faction }
+        let!(:item) { create :item, loader: 'asteroid.iron_ore', user: user, location: user.location }
 
         it 'should remove item from users location' do
           expect {
-            Item.remove_from_user(user: @user, location: @user.location, loader: @item.loader, amount: 1)
+            Item.remove_from_user(user: user, location: user.location, loader: item.loader, amount: 1)
           }.to change {
             Item.count
           }.by(-1)
         end
 
         it 'should remove item from users ship' do
-          @item.update_columns(location_id: nil, spaceship_id: @user.active_spaceship.id)
+          item.update_columns(location_id: nil, spaceship_id: user.active_spaceship.id)
           expect {
-            Item.remove_from_user(user: @user, loader: @item.loader, amount: 1)
+            Item.remove_from_user(user: user, loader: item.loader, amount: 1)
           }.to change {
             Item.count
           }.by(-1)
         end
 
         it 'should remove item from counter if less than item amount' do
-          @item.update_columns(count: 2)
+          item.update_columns(count: 2)
           expect {
-            Item.remove_from_user(user: @user, loader: @item.loader, location: @user.location, amount: 1)
+            Item.remove_from_user(user: user, loader: item.loader, location: user.location, amount: 1)
           }.to change {
             Item.count
           }.by(0)
-          expect(@item.reload.count).to eq(1)
         end
       end
 

--- a/spec/models/spaceship_spec.rb
+++ b/spec/models/spaceship_spec.rb
@@ -40,7 +40,7 @@ describe Spaceship do
         it 'should not create structure when no items' do
           expect {
             ship.drop_loot
-          }.to change{Structure.count}.by(0)
+          }.to change { Structure.count }.by(0)
         end
 
         it 'should create structure with items when ship has items in it' do
@@ -48,7 +48,7 @@ describe Spaceship do
 
           expect {
             ship.drop_loot
-          }.to change{Structure.count}.by(1)
+          }.to change { Structure.count }.by(1)
           expect(Structure.first.get_items.count).to be >= 0
         end
       end

--- a/spec/models/spaceship_spec.rb
+++ b/spec/models/spaceship_spec.rb
@@ -12,47 +12,43 @@ describe Spaceship do
     end
 
     describe 'Functions' do
-      before(:each) do
-        user = FactoryBot.create(:user_with_faction)
-        @ship = FactoryBot.create(:spaceship, user: user)
-      end
+      let(:user) { create :user_with_faction }
+      let(:ship) { create :spaceship, user: user }
 
       describe 'get_attribute' do
         it 'should return attribute of spaceship from yml' do
-          expect(@ship.get_attribute('storage')).to eq(10)
+          expect(ship.get_attribute('storage')).to eq(10)
         end
 
         it 'should return attribute of spaceship from yml when nil' do
-          expect(@ship.get_attribute('noot')).to eq(nil)
+          expect(ship.get_attribute('noot')).to eq(nil)
         end
 
         it 'should return nil if nil given' do
-          expect(@ship.get_attribute()).to eq(nil)
+          expect(ship.get_attribute()).to eq(nil)
         end
       end
 
       describe 'get_items' do
-        before(:each) do
-          Item.create(loader: 'test', spaceship: @ship, count: 2)
-        end
-
         it 'should return items in storage of ship' do
-          expect(@ship.get_items.first.count).to eq(2)
+          create :item, loader: "test", spaceship: ship, count: 2
+          expect(ship.get_items.first.count).to eq(2)
         end
       end
 
       describe 'drop_loot' do
         it 'should not create structure when no items' do
-          @ship.drop_loot
-          expect(Structure.count).to eq(1)
+          expect {
+            ship.drop_loot
+          }.to change{Structure.count}.by(0)
         end
 
-        it 'should create strcture with items when ship has items in it' do
-          2.times do
-            Item.create(loader: 'test', spaceship: @ship)
-          end
-          @ship.drop_loot
-          expect(Structure.count).to eq(2)
+        it 'should create structure with items when ship has items in it' do
+          create_list :item, 2, loader: 'test', spaceship: ship
+
+          expect {
+            ship.drop_loot
+          }.to change{Structure.count}.by(1)
           expect(Structure.first.get_items.count).to be >= 0
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,40 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Print the 4 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 4
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  config.default_formatter = 'Fuubar'
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+    config.profile_examples = 0
+  end
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
- add `has_lookup_attributes` concern for the models that user lookup data `Spaceship, Faction, Item`
- use enum scopes that Rails provides for queries where appropriate:
  - `Npc.where(npc_type: "police", target: user.id)` becomes `Npc.police.targeting_user(user)`
- replaced `ApplicationHelper.map_and_sort` with a single DB call
  - in almost all cases the DB is faster than ruby 
- replaced `ApplicationHelper.get_item_attributes` with `Item.get_attributes`

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
