### PR TITLE
FIX: Remove inactive users from hidden locations

### DIFF
--- a/runner/hidden_locations.rb
+++ b/runner/hidden_locations.rb
@@ -5,6 +5,16 @@ System.all.each do |system|
 
   # Clear all hidden locations
   system.locations.where(hidden: true).each do |loc|
+    if loc.users.present?
+      can_move = true
+      loc.users.each do |user|
+        can_move = false if user.online > 0 || user.last_action > Time.now - 1.days
+      end
+      if can_move
+        loc.users.update_all(location_id: Location.where(location_type: :station).first.id, system_id: Location.where(location_type: :station).first.system_id, docked: true)
+      end
+    end
+
     loc.destroy if loc.users.empty? && Spaceship.where(warp_target_id: loc.id).empty? && !loc.wormhole?
   end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
The current issue we have with exploration sites is that they don't get deleted when a user is still at that site. Since some players seem to log off at these locations, they never get deleted and hinder other players in exploring.

This PR will remove players that are offline for longer than 24 hours from the exploration site in order to get it clear again.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
